### PR TITLE
Add heapq and deque to Python cheatsheet

### DIFF
--- a/source/_posts/python.md
+++ b/source/_posts/python.md
@@ -300,7 +300,7 @@ heapq.heapify(myList)
 x = heapq.heappop(myList)
 print(-x) # => 9 (making sure to multiply by -1 again)
 ```
-Heaps are binary trees for which every parent node has a value less than or equal to any of its children. Useful for accessing min/max value quickly. Time complexity: O(n) for heapify, O(log n) push and pops. See: [Heapq](https://docs.python.org/3/library/heapq.html)
+Heaps are binary trees for which every parent node has a value less than or equal to any of its children. Useful for accessing min/max value quickly. Time complexity: O(n) for heapify, O(log n) push and pop. See: [Heapq](https://docs.python.org/3/library/heapq.html)
 
 ### Stacks and Queues {.row-span-3}
 ```python

--- a/source/_posts/python.md
+++ b/source/_posts/python.md
@@ -276,6 +276,54 @@ y = str(2)    # y will be '2'
 z = str(3.0)  # z will be '3.0'
 ```
 
+Python Data Structures
+-----------------------
+### Heaps {.col-span-2 .row-span-3}
+```python
+import heapq
+
+myList = [9, 5, 4, 1, 3, 2]
+heapq.heapify(myList) # turn myList into a Min Heap
+print(myList) # => [1, 3, 2, 5, 9, 4]
+print(myList[0]) # first value is always the smallest in the heap
+
+heapq.heappush(myList, 10) # insert 10
+x = heapq.heappop(myList) # pop and return smallest item
+print(x) # => 1
+```
+#### Negate all values to use Min Heap as Max Heap 
+```python
+myList = [9, 5, 4, 1, 3, 2]
+myList = [-val for val in myList] # multiply by -1 to negate
+heapq.heapify(myList)
+
+x = heapq.heappop(myList)
+print(-x) # => 9 (making sure to multiply by -1 again)
+```
+Heaps are binary trees for which every parent node has a value less than or equal to any of its children. Useful for accessing min/max value quickly. See: [Heapq](https://docs.python.org/3/library/heapq.html)
+
+### Stacks and Queues {.row-span-3}
+```python
+from collections import deque
+
+q = deque() # empty
+q = deque([1, 2, 3]) # with values
+
+q.append(4) # append to right side
+q.appendleft(0) # append to left side
+print(q) # => deque([0, 1, 2, 3, 4])
+
+x = q.pop() # remove & return from right
+y = q.popleft() # remove & return from left
+print(x) # => 4
+print(y) # => 0
+print(q) # => deque([1, 2, 3])
+
+q.rotate(1) # rotate 1 step to the right
+print(q) # => deque([3, 1, 2])
+```
+Deque is a double-ended queue with O(1) time for append/pop operations from both sides. Used as stacks and queues. See: [Deque](https://docs.python.org/3/library/collections.html#collections.deque)
+
 
 
 Python Strings

--- a/source/_posts/python.md
+++ b/source/_posts/python.md
@@ -300,7 +300,7 @@ heapq.heapify(myList)
 x = heapq.heappop(myList)
 print(-x) # => 9 (making sure to multiply by -1 again)
 ```
-Heaps are binary trees for which every parent node has a value less than or equal to any of its children. Useful for accessing min/max value quickly. See: [Heapq](https://docs.python.org/3/library/heapq.html)
+Heaps are binary trees for which every parent node has a value less than or equal to any of its children. Useful for accessing min/max value quickly. Time complexity: O(n) for heapify, O(log n) push and pops. See: [Heapq](https://docs.python.org/3/library/heapq.html)
 
 ### Stacks and Queues {.row-span-3}
 ```python

--- a/source/_posts/python.md
+++ b/source/_posts/python.md
@@ -164,7 +164,7 @@ See: [Python F-Strings](#python-f-strings-since-python)
 
 
 
-Python Data Types
+Python Built-in Data Types
 ---------------
 
 
@@ -276,7 +276,7 @@ y = str(2)    # y will be '2'
 z = str(3.0)  # z will be '3.0'
 ```
 
-Python Data Structures
+Python Advanced Data Types
 -----------------------
 ### Heaps {.col-span-2 .row-span-3}
 ```python


### PR DESCRIPTION
Since I'm prepping for coding interviews, I've added some common data structures from Python's standard library to the cheat sheet. Feel free to edit it to make the style look better. I tried my best to make it look clean while still explaining it clearly (heapq is somewhat unintuitive without the comments).

#### Changes:
- Rename the 'Python Data Type' section to 'Python Built-in Data Types'
- Add new section underneath that titled 'Python Advanced Data Types'
    - Add Python's min-heap from the standard library ('heapq')
    - Add Python's double-ended queue from the standard library (deque)

### Preview:
#### Previous
![prev_datatypes_heading](https://user-images.githubusercontent.com/28739845/203185108-2f00fb36-68f9-41d9-910b-f8cf0d42ebbe.jpg)
#### New
![new_datatypes_heading](https://user-images.githubusercontent.com/28739845/203185123-62902dd8-082f-4da1-86bf-eaa727e38627.jpg)

![new_advdatatypes](https://user-images.githubusercontent.com/28739845/203185137-0648c07e-461d-407a-ad9c-b5f820d0118c.jpg)