### PR TITLE
Correct the `--include` option

### DIFF
--- a/source/_posts/curl.md
+++ b/source/_posts/curl.md
@@ -148,7 +148,7 @@ command | description
 ### Multiple file upload {.col-span-2}
 
 ```bash
-$ curl -v -include \
+$ curl -v --include \
 --form key1=value1 \
     --form upload=@localfilename URL
 ```


### PR DESCRIPTION
`-include` is invalid, it is intercepted as `-i -n -c` and will create a file named `lude` under the current directory.