### PR TITLE
a typo in postgres

### DIFF
--- a/source/_posts/postgres.md
+++ b/source/_posts/postgres.md
@@ -259,7 +259,7 @@ VALUES ( <value1>,<value2> );
 
 
 ### Data
-[Select](http://www.postgresql.org/docs/current/static/sql-select.html] all data
+[Select](http://www.postgresql.org/docs/current/static/sql-select.html) all data
 ```sql  {.wrap}
 SELECT * FROM <table_name>;
 ```


### PR DESCRIPTION
`]` should be `)`