### PR TITLE
Update rust.md, fix the match expression

### DIFF
--- a/source/_posts/rust.md
+++ b/source/_posts/rust.md
@@ -529,33 +529,32 @@ else {
 
 ```rust
 let day_of_week = 2;
-  match day_of_week {
-    1 => {
-      println!("Its Monday my dudes");
-    },
-    2 => {
-      println!("It's Tuesday my dudes");
-    },
-    3 => {
-      println!("It's Wednesday my dudes");
-    },
-    4 => {
-      println!("It's Thursday my dudes");
-    },
-    5 => {
-      println!("It's Friday my dudes");
-    },
-    6 => {
-      println!("It's Saturday my dudes");
-    },
-    7 => {
-      println!("It's Sunday my dudes");
-    },
-    _ => {
-      println!("Default!")
-    }
-  };
-}
+match day_of_week {
+  1 => {
+    println!("Its Monday my dudes");
+  },
+  2 => {
+    println!("It's Tuesday my dudes");
+  },
+  3 => {
+    println!("It's Wednesday my dudes");
+  },
+  4 => {
+    println!("It's Thursday my dudes");
+  },
+  5 => {
+    println!("It's Friday my dudes");
+  },
+  6 => {
+    println!("It's Saturday my dudes");
+  },
+  7 => {
+    println!("It's Sunday my dudes");
+  },
+  _ => {
+    println!("Default!")
+  }
+};
 ```    
 
 


### PR DESCRIPTION
The Match Expression section has an extra '}'