### PR TITLE
Fix known_hosts explanation

### DIFF
--- a/source/_posts/ssh.md
+++ b/source/_posts/ssh.md
@@ -84,7 +84,7 @@ $ scp user@server:/dir/* .
 | `~/.ssh/config`          | User-specific config |
 | `~/.ssh/id_{type}`       | Private key          |
 | `~/.ssh/id_{type}.pub`   | Public key           |
-| `~/.ssh/known_hosts`     | Logged in host       |
+| `~/.ssh/known_hosts`     | Known Servers        |
 | `~/.ssh/authorized_keys` | Authorized login key |
 
 


### PR DESCRIPTION
`known_hosts` doesn't save the _current_ logged in servers. Instead, it saves the previous servers.

I thus think "Known Servers" is more correct. I use "servers" instead of "hosts" because I think it's more clear.