### PR TITLE
fix: Fix Back & Forward Navigation in Firefox

### DIFF
--- a/source/_posts/firefox.md
+++ b/source/_posts/firefox.md
@@ -23,8 +23,8 @@ Keyboard Shortcuts
 
 Shortcut | Action
 ---|---
-`Ctrl` `Left`  | Back
-`Ctrl` `Right`  | Forward
+`Alt` `Left`  | Back
+`Alt` `Right`  | Forward
 `Alt` `Home`  | Home
 `Ctrl` `O`  | Open File
 `Ctrl` `R`  | Reload


### PR DESCRIPTION
The current indicators for back and forward navigation for Firefox browser are incorrect and have been replaced with the correct ones.