### PR TITLE
Style scrollbars for Webkit browsers

### DIFF
--- a/themes/coo/source/css/style.tailwindcss
+++ b/themes/coo/source/css/style.tailwindcss
@@ -28,6 +28,11 @@ html.scrollbar {
     scroll-padding-top: 20px;
 }
 
+/***Scrollbars***/
+:root.dark {
+    color-scheme: dark;
+}
+
 .max-container {
     max-width: 1320px;
     @apply mx-auto p-3;

--- a/themes/coo/source/css/style.tailwindcss
+++ b/themes/coo/source/css/style.tailwindcss
@@ -33,6 +33,23 @@ html.scrollbar {
     color-scheme: dark;
 }
 
+/* Restrict changes to mouse users */
+@media (pointer: fine) {
+    ::-webkit-scrollbar {
+        @apply bg-slate-200 w-2 h-2 rounded-lg
+    }
+    ::-webkit-scrollbar-thumb {
+        @apply bg-slate-300 rounded-lg
+    }
+
+    :root.dark ::-webkit-scrollbar {
+        @apply bg-slate-700
+    }
+    :root.dark ::-webkit-scrollbar-thumb {
+        @apply bg-slate-500
+    }
+}
+
 .max-container {
     max-width: 1320px;
     @apply mx-auto p-3;


### PR DESCRIPTION
Adds scrollbar colors and styles them to match the site a little better.

Currently, the scrollbars do not match the theme on webkit based browsers (chrome, edge, etc.). This does not affect browsers which do not use webkit (e.g. firefox) as they handle scrollbars differently. This pull request adds styles to them for users with a pointer and just corrects the `color-scheme` for everyone else.

The changes are made through Tailwind via the `@apply` property, so no magic numbers.

## Before:

|Dark|Light|
|-|-|
|![dark mode](https://github.com/Fechin/reference/assets/109556932/37969ea0-2770-4858-a623-f9d5a7706b58)|![light mode](https://github.com/Fechin/reference/assets/109556932/45691030-1a32-4824-9e8a-83aca10310f2)|
|![dark mode](https://github.com/Fechin/reference/assets/109556932/f6ed7d7e-f27b-4733-9e31-13baee76f9c2)|![light mode](https://github.com/Fechin/reference/assets/109556932/2189253d-ab56-4bc7-8fd1-b58b4608c3df)|

## After:

|Dark|Light|
|-|-|
|![dark mode](https://github.com/Fechin/reference/assets/109556932/a44c887a-137d-4ded-9678-cf8f73b87b41)|![light mode](https://github.com/Fechin/reference/assets/109556932/69b1c9ba-cd9b-4f87-8461-47b659be127e)
|![dark mode](https://github.com/Fechin/reference/assets/109556932/f6180ce4-ac59-45eb-8f41-9407f1706d29)|![light mode](https://github.com/Fechin/reference/assets/109556932/132c8e71-c0ba-4a0e-a108-204d9886fe74)|

## Concerns

This change modifies the size of the scrollbar which could possibly be an accessibility concern. It is possible to remove the extra styles and just keep the `color-scheme` if that is the case.

> When customizing scrollbars, ensure that the thumb and track have enough contrast with the surrounding background. Also ensure that the scrollbar hit area is large enough for people who use touch input.
> &ndash;[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scrollbars_styling)

Another concern is the use of `.dark` to hook into dark mode. The current tailwind settings [set the dark mode to be set with a class](https://github.com/Fechin/reference/blob/main/tailwind.config.js#L2), but this could theoretically be changed, leading to this breaking. This specific scenario is unlikely as the `'media'` option also breaks the theme switcher, but it is technically one possible issue.

## Possible Other Solutions

This change works on the scrollbars by styling them directly. It is also possible to just use the `color-scheme` property on the `HTML` element when there is the `.dark` class. This would address the issue of the changed size.

I have separated the dark mode scrollbar colors and the styled scrollbars into separate commits, so feel free to revert the style scrollbars commit if this seems to be the better solution.

Here is what that would result in:

![horizontal scrollbars](https://github.com/Fechin/reference/assets/109556932/7506b036-854e-4fb6-87e4-f1c28b73db8f)

![vertical scrollbars](https://github.com/Fechin/reference/assets/109556932/00839031-2282-472a-a796-3271553954dc)
