### PR TITLE
docs(canvas): fix typo

### DIFF
--- a/source/_posts/canvas.md
+++ b/source/_posts/canvas.md
@@ -12,7 +12,7 @@ plugins:
   - copyCode
 ---
 
-## Geting Started
+## Getting Started
 
 ### Basic Setup
 


### PR DESCRIPTION
Fix typo on Getting Started heading for Canvas cheatsheet