### PR TITLE
remove twitter icon (follow me) in header

### DIFF
--- a/themes/coo/layout/_partial/header.ejs
+++ b/themes/coo/layout/_partial/header.ejs
@@ -18,7 +18,7 @@
                 <a href="<%- edit_page() %>" target="_blank">
                     <img alt="GitHub Repo stars" style="height: 26px; opacity: 0.8;" src="https://img.shields.io/github/stars/Fechin/reference?style=social">
                 </a>
-                <a href="https://twitter.com/FechinLi" target="_blank">
+                <!-- <a href="https://twitter.com/FechinLi" target="_blank">
                     <button type="button"
                             class="fadeIn inline-flex h-8 items-center rounded-full  bg-[#4d9feb] text-slate-100 ml-1 lg:ml-4 px-2 md:px-3 py-2 md:hover:opacity-80">
                         <div class="md:mr-2">
@@ -26,7 +26,7 @@
                         </div>
                         <span class="hidden md:inline text-sm">Follow Me</span>
                     </button>
-                </a>
+                </a> -->
                 <button id="darkMode" class="fadeIn inline-flex items-center justify-center flex-shrink-0 h-8 w-8 rounded-full text-gray-900 ml-1 lg:ml-4 dark:text-gray-300 bg-gray-200 dark:bg-gray-900">
                     <i class="icon-light text-gray-600 dark:text-gray-300 dark:hover:text-white">
                         <%- icon("light") %>


### PR DESCRIPTION
Removed the Twitter icon from the header as it was already present in bottom of the page. This eliminates redundancy, preventing two identical Twitter icons from appearing on the page.
I know both icon works are different but icon are same and now it feels better.