### PR TITLE
fix: sed line number incorrect

### DIFF
--- a/source/_posts/sed.md
+++ b/source/_posts/sed.md
@@ -240,7 +240,7 @@ $ sed = file.txt | sed 'N;s/\n/\t/'
 Number line of a file (number on left, right-aligned)
 
 ```shell script
-$ sed = file.txt | sed 'N; s/^/   /; s/ *\(.\{6,\}\)\n/\1  /'
+$ sed = file.txt | sed 'N; s/^/     /; s/ *\(.\{6\}\)\n/\1  /'
 ```
 
 Number line of file, but only print numbers if line is not blank


### PR DESCRIPTION
The original code for prefixing line numbers was not working, as it was adding less extra space than needed:

```
seq 3 | sed = | sed 'N; s/^/   /; s/ *\(.\{6,\}\)\n/\1/'
   1
1
   2
2
   3
3
```

Adding few more spaces fixes the issue:

```
seq 3 | sed = | sed 'N; s/^/     /; s/ *\(.\{6\}\)\n/\1 /'
     1 1
     2 2
     3 3
```

I've also changed `\{6,\}` to `\{6\}`, as the extra `,` shouln't be needed and might be confusing.