### PR TITLE
Fix incorrect JQuery snippet

### DIFF
--- a/source/_posts/jquery.md
+++ b/source/_posts/jquery.md
@@ -39,7 +39,7 @@ $(selector).methodOrFunction();
 #### Example:
 
 ```javascript
-$("#menu").on("click", () => {
+$("#menu").on("click", function () {
   $(this).hide();
 });
 


### PR DESCRIPTION
The snippet showcasing the `$(this)` example does not work as intended.

Arrow functions [do not have `this`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) and you must use the other type of anonymous functions to use it.

We can note that the other example of an anonymous function&mdash;the after-document-load shorthand `$(function () {})` uses the regular anonymous function as it would otherwise also break the use of `this`.

CodePen showing both versions of this change: https://codepen.io/fireisgood/pen/qEWOYZz