### PR TITLE
Improve docker build for ready to cicd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Stage 1: build the application
 FROM nginx:alpine AS build-nginx
+WORKDIR /app
 RUN apk add nodejs npm
 COPY . .
 RUN npm i

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 # Stage 1: build the application
-FROM nginx:alpine AS build-nginx
+FROM node:19 as build-app
 WORKDIR /app
-RUN apk add nodejs npm
 COPY . .
 RUN npm i
 RUN npm run build
+
+# Stage 2: Build nginx 
+FROM nginx:alpine AS build-nginx
+WORKDIR /usr/share/nginx/html/
+COPY --from=build-app /app/public /usr/share/nginx/html/
 RUN rm -rf /etc/nginx/conf.d/*
 COPY nginx.conf /etc/nginx/
-COPY public /usr/share/nginx/html/
 EXPOSE 80
 
 # Stage 2: final image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
 # Stage 1: build the application
-FROM nginx:alpine AS build
+FROM nginx:alpine AS build-nginx
+RUN apk add nodejs npm
+COPY . .
+RUN npm i
+RUN npm run build
 RUN rm -rf /etc/nginx/conf.d/*
 COPY nginx.conf /etc/nginx/
-RUN npm image
-RUN npm run build
 COPY public /usr/share/nginx/html/
 EXPOSE 80
 
 # Stage 2: final image
 FROM alpine:latest
 RUN apk add --no-cache nginx && mkdir -p /run/nginx
-COPY --from=build /usr/share/nginx/html/ /usr/share/nginx/html/
-COPY --from=build /etc/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY --from=build-nginx /usr/share/nginx/html/ /usr/share/nginx/html/
+COPY --from=build-nginx /etc/nginx/nginx.conf /etc/nginx/nginx.conf
 EXPOSE 80
 HEALTHCHECK --interval=1s --timeout=3s CMD wget -q -O - http://localhost:80 || exit 1
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM nginx:alpine AS build
 RUN rm -rf /etc/nginx/conf.d/*
 COPY nginx.conf /etc/nginx/
+RUN npm image
+RUN npm run build
 COPY public /usr/share/nginx/html/
 EXPOSE 80
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "hexo-server": "^2.0.0",
     "markdown-it-abbr": "^1.0.4",
     "markdown-it-anchor": "^8.4.1",
-    "markdown-it-attrs": "^4.1.0",
+    "markdown-it-attrs": "^4.3.1",
     "markdown-it-checkbox": "^1.1.0",
     "markdown-it-emoji": "^2.0.0",
     "markdown-it-footnote": "^3.0.3",


### PR DESCRIPTION
I attempted to deploy this code on my server, but I encountered errors each time I tried to build the Docker file. The most significant error occurred while building one of the markdown packages. Upon investigation, I realized I needed to contribute to one of the libraries and resolve the build issue that had arisen here. Fortunately, this task was accomplished today with the assistance of the markdown-it-attr library developer, and the crash problem during the build was resolved. However, the Docker file still had issues deploying independently on the server. After repeated tests and improvements, the Dockerfile now builds successfully and can be deployed on any server.
In the next phase, I am now able to add more code snippets to this open system, and I intend to add GitHub Actions to this repository so that Docker images are automatically built and made publicly available. I would appreciate it if you could merge these improvements into the main repository.