### PR TITLE
Add support for running code

### DIFF
--- a/source/_posts/javascript.md
+++ b/source/_posts/javascript.md
@@ -11,6 +11,7 @@ intro: |
   A JavaScript cheat sheet with the most important concepts, functions, methods, and more. A complete quick reference for beginners.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started

--- a/source/_posts/jquery.md
+++ b/source/_posts/jquery.md
@@ -14,19 +14,20 @@ intro: |
 plugins:
   - tooltip
   - copyCode
+  - runCode
 ---
 
 ## Getting Started
 
 ### Including jQuery
 
-```javascript {.wrap}
+```html {.wrap}
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 ```
 
 #### Official CDN
 
-```javascript {.wrap}
+```html {.wrap}
 <script src="https://code.jquery.com/jquery-3.5.1.min.js" crossorigin="anonymous"></script>
 ```
 

--- a/source/_posts/markdown.md
+++ b/source/_posts/markdown.md
@@ -12,6 +12,7 @@ categories:
 intro: This is a quick reference cheat sheet to the Markdown syntax.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Markdown Quick Reference

--- a/source/_posts/python.md
+++ b/source/_posts/python.md
@@ -11,6 +11,7 @@ intro: |
   The [Python](https://www.python.org/) cheat sheet is a one-page reference sheet for the Python 3 programming language.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started

--- a/source/_posts/sass.md
+++ b/source/_posts/sass.md
@@ -11,6 +11,7 @@ intro: |
   This is a quick reference cheat sheet that lists the most useful features of [SASS](https://sass-lang.com).
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Sass Basics

--- a/source/_posts/typescript.md
+++ b/source/_posts/typescript.md
@@ -11,6 +11,7 @@ intro: |
   A TypeScript cheat sheet with the most important concepts, functions, methods, and more. A complete quick reference for beginners.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started
@@ -293,11 +294,7 @@ class Greeter {
 
 ```ts
 function enumerable(value: boolean) {
-  return function (
-    target: any,
-    propertyKey: string,
-    descriptor: PropertyDescriptor
-  ) {
+  return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
     descriptor.enumerable = value;
   };
 }

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -81,6 +81,11 @@
         const code_Blocks = document.querySelectorAll('pre > code');
         const runInnerHTML = '<svg height="1em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g stroke-width="0"></g><g stroke-linecap="round" stroke-linejoin="round"></g><g><path d="M16.6582 9.28638C18.098 10.1862 18.8178 10.6361 19.0647 11.2122C19.2803 11.7152 19.2803 12.2847 19.0647 12.7878C18.8178 13.3638 18.098 13.8137 16.6582 14.7136L9.896 18.94C8.29805 19.9387 7.49907 20.4381 6.83973 20.385C6.26501 20.3388 5.73818 20.0469 5.3944 19.584C5 19.053 5 18.1108 5 16.2264V7.77357C5 5.88919 5 4.94701 5.3944 4.41598C5.73818 3.9531 6.26501 3.66111 6.83973 3.6149C7.49907 3.5619 8.29805 4.06126 9.896 5.05998L16.6582 9.28638Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"></path></g></svg>';
         code_Blocks.forEach(function (codeBlock) {
+            let content = codeBlock.textContent;
+            let language = [...codeBlock.classList].filter(c => c.startsWith("language-"))[0].replace("language-", "");
+
+            if (language === 'shell') return;
+
             // Create a run button element
             const runButton = document.createElement('button');
             runButton.className = 'bg-emerald-500 p-2 text-white fadeIn shadow-xl rounded flex items-center absolute top-12 right-2';
@@ -93,9 +98,11 @@
 
             // Add click event listener to run button
             runButton.addEventListener('click', () => {
-                let content = codeBlock.textContent;
-                let language = [...codeBlock.classList].filter(c => c.startsWith("language-"))[0].replace("language-", "");
-                const editorId = ['javascript', 'python'].includes(language) 
+                if (language === 'ts') {
+                    language = 'typescript';
+                }
+                
+                const editorId = ['javascript', 'typescript', 'python'].includes(language) 
                                     ? 'script' 
                                     : ['scss'].includes(language) 
                                         ? 'style' 
@@ -145,7 +152,7 @@
                     }
                 }
 
-                if (language === 'scss') {
+                if (['scss', 'typescript'].includes(language)) {
                     config = {
                         ...baseConfig,
                         tools: {

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -91,27 +91,27 @@
             parent.style = "position: relative;"
             parent.insertBefore(runButton, codeBlock);
 
-            let content = codeBlock.textContent;
-            let language = [...codeBlock.classList].filter(c => c.startsWith("language-"))[0].replace("language-", "");
-            const editorId = ['javascript', 'python'].includes(language) ? 'script' : 'markup';
-            const title = codeBlock.closest('.h3-wrap')?.querySelector('h3')?.textContent.replace('#', '') || '';
-
-            if (language === 'python') {
-                if (content.includes('>>> ')) {
-                    content = content
-                        .trim()
-                        .split('\n')
-                        .map(line => line.startsWith('>>> ') ? line.replace('>>> ', '') : `# ${line}`)
-                        .join('\n');
-                }
-                if (content.includes('from typing import')) {
-                    language = 'python-wasm';
-                }
-            }
-
             // Add click event listener to run button
             runButton.addEventListener('click', () => {
-                const config = {
+                let content = codeBlock.textContent;
+                let language = [...codeBlock.classList].filter(c => c.startsWith("language-"))[0].replace("language-", "");
+                const editorId = ['javascript', 'python'].includes(language) ? 'script' : 'markup';
+                const title = codeBlock.closest('.h3-wrap')?.querySelector('h3')?.textContent.replace('#', '') || '';
+
+                if (language === 'python') {
+                    if (content.includes('>>> ')) {
+                        content = content
+                            .trim()
+                            .split('\n')
+                            .map(line => line.startsWith('>>> ') ? line.replace('>>> ', '') : `# ${line}`)
+                            .join('\n');
+                    }
+                    if (content.includes('from typing import')) {
+                        language = 'python-wasm';
+                    }
+                }
+
+                let config = {
                     title,
                     activeEditor: editorId,
                     [editorId]: {
@@ -120,6 +120,23 @@
                     },
                     tools: {
                         status: 'open',
+                    }
+                }
+
+                if (language === 'markdown') {
+                    config = {
+                        ...config,
+                        style: {
+                            language: 'css',
+                            content: '@import "github-markdown-css";\n\nbody {\n  border: 1px solid #e1e4e8;\n  border-radius: 4px;\n  padding: 20px;\n  margin: 20px !important;\n}\n',
+                        },
+                        script: {
+                            language: 'javascript',
+                            content: 'document.body.classList.add("markdown-body");'
+                        },
+                        tools: {
+                            status: 'closed',
+                        }
                     }
                 }
 

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -95,7 +95,11 @@
             runButton.addEventListener('click', () => {
                 let content = codeBlock.textContent;
                 let language = [...codeBlock.classList].filter(c => c.startsWith("language-"))[0].replace("language-", "");
-                const editorId = ['javascript', 'python'].includes(language) ? 'script' : 'markup';
+                const editorId = ['javascript', 'python'].includes(language) 
+                                    ? 'script' 
+                                    : ['scss'].includes(language) 
+                                        ? 'style' 
+                                        : 'markup';
                 const title = codeBlock.closest('.h3-wrap')?.querySelector('h3')?.textContent.replace('#', '') || '';
 
                 if (language === 'python') {
@@ -111,7 +115,7 @@
                     }
                 }
 
-                let config = {
+                const baseConfig = {
                     title,
                     activeEditor: editorId,
                     [editorId]: {
@@ -122,10 +126,11 @@
                         status: 'open',
                     }
                 }
+                let config = baseConfig;
 
                 if (language === 'markdown') {
                     config = {
-                        ...config,
+                        ...baseConfig,
                         style: {
                             language: 'css',
                             content: '@import "github-markdown-css";\n\nbody {\n  border: 1px solid #e1e4e8;\n  border-radius: 4px;\n  padding: 20px;\n  margin: 20px !important;\n}\n',
@@ -136,6 +141,16 @@
                         },
                         tools: {
                             status: 'closed',
+                        }
+                    }
+                }
+
+                if (language === 'scss') {
+                    config = {
+                        ...baseConfig,
+                        tools: {
+                            status: 'open',
+                            active: 'compiled',
                         }
                     }
                 }

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -72,3 +72,67 @@
         });
     </script>
 <% } %>
+
+
+<% if (is_post() && page.plugins != undefined && page.plugins.includes("runCode") ){ %>
+    <script src="https://cdn.jsdelivr.net/npm/livecodes@0.7.2/livecodes.umd.js"></script>
+    <script>
+        // Get all pre > code elements
+        const code_Blocks = document.querySelectorAll('pre > code');
+        const runInnerHTML = '<svg height="1em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g stroke-width="0"></g><g stroke-linecap="round" stroke-linejoin="round"></g><g><path d="M16.6582 9.28638C18.098 10.1862 18.8178 10.6361 19.0647 11.2122C19.2803 11.7152 19.2803 12.2847 19.0647 12.7878C18.8178 13.3638 18.098 13.8137 16.6582 14.7136L9.896 18.94C8.29805 19.9387 7.49907 20.4381 6.83973 20.385C6.26501 20.3388 5.73818 20.0469 5.3944 19.584C5 19.053 5 18.1108 5 16.2264V7.77357C5 5.88919 5 4.94701 5.3944 4.41598C5.73818 3.9531 6.26501 3.66111 6.83973 3.6149C7.49907 3.5619 8.29805 4.06126 9.896 5.05998L16.6582 9.28638Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"></path></g></svg>';
+        code_Blocks.forEach(function (codeBlock) {
+            // Create a run button element
+            const runButton = document.createElement('button');
+            runButton.className = 'bg-emerald-500 p-2 text-white fadeIn shadow-xl rounded flex items-center absolute top-12 right-2';
+            runButton.innerHTML = runInnerHTML;
+            runButton.style.opacity = "0";
+            const parent = codeBlock.parentNode;
+
+            parent.style = "position: relative;"
+            parent.insertBefore(runButton, codeBlock);
+
+            let content = codeBlock.textContent;
+            let language = [...codeBlock.classList].filter(c => c.startsWith("language-"))[0].replace("language-", "");
+            const editorId = ['javascript', 'python'].includes(language) ? 'script' : 'markup';
+            const title = codeBlock.closest('.h3-wrap')?.querySelector('h3')?.textContent.replace('#', '') || '';
+
+            if (language === 'python') {
+                if (content.includes('>>> ')) {
+                    content = content
+                        .trim()
+                        .split('\n')
+                        .map(line => line.startsWith('>>> ') ? line.replace('>>> ', '') : `# ${line}`)
+                        .join('\n');
+                }
+                if (content.includes('from typing import')) {
+                    language = 'python-wasm';
+                }
+            }
+
+            // Add click event listener to run button
+            runButton.addEventListener('click', () => {
+                const config = {
+                    title,
+                    activeEditor: editorId,
+                    [editorId]: {
+                        language,
+                        content,
+                    },
+                    tools: {
+                        status: 'open',
+                    }
+                }
+
+                const plaugroundUrl = livecodes.getPlaygroundUrl({config});
+                window.open(plaugroundUrl, '_blank');
+            });
+
+            parent.addEventListener('mouseenter', () => {
+                runButton.style.opacity = "1";
+            });
+            parent.addEventListener('mouseleave', () => {
+                runButton.style.opacity = "0";
+            });
+        });
+    </script>
+<% } %>

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -155,6 +155,19 @@
                     }
                 }
 
+                if (document.querySelector('h1').textContent.includes('jQuery')) {
+                    config = {
+                        ...baseConfig,
+                        markup: {
+                            language: 'html',
+                            content: `<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></scr` + 'ipt>\n',
+                        },
+                        tools: {
+                            status: 'closed',
+                        }
+                    }
+                }
+
                 const plaugroundUrl = livecodes.getPlaygroundUrl({config});
                 window.open(plaugroundUrl, '_blank');
             });

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -147,7 +147,8 @@
                             content: 'document.body.classList.add("markdown-body");'
                         },
                         tools: {
-                            status: 'closed',
+                            status: 'open',
+                            active: 'compiled',
                         }
                     }
                 }


### PR DESCRIPTION
This PR adds support for running code in [LiveCodes](https://livecodes.io/), the [open-source](https://github.com/live-codes/livecodes) code playground (as discussed in #626 ). See [docs](https://livecodes.io/docs/).
This is still WIP. I want to gradually implement more languages, ask for comments and get feedback.

A new button is added below the copy button that is visible on hover and opens a new window that runs the selected block code in LiveCodes. The user can edit the code, see the result and, for some languages like markdown, scss and typescript, see the compiled code.

Currently, the following languages are implemented:
- JavaScript
- TypeScript
- Python
- Markdown
- Sass
- jQuery

In some languages I had to edit the content. For example running this as Python results in error:
```py
>>> msg = "Hello, World!"
>>> print(msg[2:5])
llo
```

So I automatically remove ">>> " and convert lines with no prefix to comments, to become like this: [see demo](https://livecodes.io/?x=id/wwwa686v6zc)

```py
msg = "Hello, World!"
print(msg[2:5])
# llo
```

In markdown, I add some css and js to make the output look pretty and similar to GitHub styles. (see screenshots below)
Is that ok, or shall I just keep it as it is?

If you are happy with this progress and don't have major comments, I'll continue implementing more languages.

Thank you.

### Screenshots

![image](https://github.com/user-attachments/assets/be00374e-9c7a-441c-a0f7-074198d02a3e)

![image](https://github.com/user-attachments/assets/dcc9ec9b-9724-438c-a2b5-49beaf250eb0)

![Screenshot (257)](https://github.com/user-attachments/assets/06d48175-7ba8-496d-8b17-3efef05c6e16)

![image](https://github.com/user-attachments/assets/74929252-04b8-477f-939d-23a1d0904c8e)

![image](https://github.com/user-attachments/assets/9e64e2ee-b667-414c-a23f-13784f83b10f)

closes #626 