### PR TITLE
Add support to run code for more languages

### DIFF
--- a/source/_posts/c.md
+++ b/source/_posts/c.md
@@ -9,6 +9,7 @@ intro: |
   C quick reference cheat sheet that provides basic syntax and methods.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started
@@ -58,7 +59,7 @@ int y = 6;
 int sum = x + y; // add variables to sum
 
 // declare multiple variables
-int x = 5, y = 6, z = 50;
+int a = 5, b = 6, c = 50;
 ```
 
 ### Constants

--- a/source/_posts/canvas.md
+++ b/source/_posts/canvas.md
@@ -10,6 +10,7 @@ intro: |
   This HTML  Canvas quick reference cheat sheet lists the common HTML5  Canvas design tags in readable layout.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started
@@ -23,12 +24,7 @@ plugins:
     <title>Canvas Example</title>
   </head>
   <body>
-    <canvas
-      id="myCanvas"
-      width="500"
-      height="400"
-      style="border:1px solid #000000;"
-    ></canvas>
+    <canvas id="myCanvas" width="500" height="400" style="border:1px solid #000000;"></canvas>
     <script src="script.js"></script>
   </body>
 </html>

--- a/source/_posts/cpp.md
+++ b/source/_posts/cpp.md
@@ -9,6 +9,7 @@ intro: |
   C++ quick reference cheat sheet that provides basic syntax and methods.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started
@@ -467,6 +468,7 @@ for(int i = 1; i > 0; i++) {
 
 ```cpp
 #include <iostream>
+#include <array>
 
 int main()
 {

--- a/source/_posts/css3.md
+++ b/source/_posts/css3.md
@@ -12,6 +12,7 @@ intro: |
   This is a quick reference cheat sheet for CSS goodness, listing selector syntax, properties, units and other useful bits of information.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started
@@ -66,10 +67,14 @@ Overrides all previous styling rules.
 ### Selector
 
 ```css
-h1 { }
-#job-title { }
-div.hero { }
-div > p { }
+h1 {
+}
+#job-title {
+}
+div.hero {
+}
+div > p {
+}
 ```
 
 See: [Selectors](#css-selectors)
@@ -245,7 +250,10 @@ p:first-child {
 | `div,p`      | All divs and paragraphs     |
 | `#idname *`  | All elements inside #idname |
 
-See also: [Type](https://developer.mozilla.org/en-US/docs/Web/CSS/Type_selectors) / [Class](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors) / [ID](https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors) / [Universal](https://developer.mozilla.org/en-US/docs/Web/CSS/Universal_selectors) selectors
+See also: [Type](https://developer.mozilla.org/en-US/docs/Web/CSS/Type_selectors) /
+[Class](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors) /
+[ID](https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors) /
+[Universal](https://developer.mozilla.org/en-US/docs/Web/CSS/Universal_selectors) selectors
 
 ### Combinators
 
@@ -258,7 +266,9 @@ See also: [Type](https://developer.mozilla.org/en-US/docs/Web/CSS/Type_selectors
 | `div + p`       | P tags immediately after div          |
 | `div ~ p`       | P tags preceded by div                |
 
-See also: [Adjacent](https://developer.mozilla.org/en-US/docs/Web/CSS/Adjacent_sibling_combinator) / [Sibling](https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator) / [Child](https://developer.mozilla.org/en-US/docs/Web/CSS/Child_combinator) selectors
+See also: [Adjacent](https://developer.mozilla.org/en-US/docs/Web/CSS/Adjacent_sibling_combinator) /
+[Sibling](https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator) /
+[Child](https://developer.mozilla.org/en-US/docs/Web/CSS/Child_combinator) selectors
 
 ### Attribute selectors
 
@@ -345,12 +355,10 @@ See also: [Attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS
 | `letter-spacing:` | \<size>         |
 | `line-height:`    | \<number>       |
 
-| `font-weight:` | \<number> / bold / normal |
-| `font-style:` | italic / normal |
-| `text-decoration:` | underline / none |
+| `font-weight:` | \<number> / bold / normal | | `font-style:` | italic / normal | | `text-decoration:` | underline /
+none |
 
-| `text-align:` | left / right<br>center / justify |
-| `text-transform:` | capitalize / uppercase / lowercase |
+| `text-align:` | left / right<br>center / justify | | `text-transform:` | capitalize / uppercase / lowercase |
 {.left-text}
 
 See also: [Font](https://developer.mozilla.org/en-US/docs/Web/CSS/font)
@@ -453,14 +461,10 @@ color: currentcolor; /* keyword */
 | ------------- | ------------- |
 | `background:` | _(Shorthand)_ |
 
-| `background-color:` | See: [Colors](#css-colors) |
-| `background-image:` | url(...) |
-| `background-position:` | left/center/right<br/>top/center/bottom |
-| `background-size:` | cover X Y |
-| `background-clip:` | border-box<br/>padding-box<br/>content-box |
-| `background-repeat:` | no-repeat<br/>repeat-x<br/>repeat-y |
-| `background-attachment:` | scroll/fixed/local |
-{.left-text}
+| `background-color:` | See: [Colors](#css-colors) | | `background-image:` | url(...) | | `background-position:` |
+left/center/right<br/>top/center/bottom | | `background-size:` | cover X Y | | `background-clip:` |
+border-box<br/>padding-box<br/>content-box | | `background-repeat:` | no-repeat<br/>repeat-x<br/>repeat-y | |
+`background-attachment:` | scroll/fixed/local | {.left-text}
 
 ### Shorthand {.secondary .col-span-2}
 
@@ -475,16 +479,12 @@ color: currentcolor; /* keyword */
 ```css {.wrap}
 background: url(img_man.jpg) no-repeat center;
 
-background: url(img_flwr.gif) right bottom no-repeat, url(paper.gif) left top
-    repeat;
+background:
+  url(img_flwr.gif) right bottom no-repeat,
+  url(paper.gif) left top repeat;
 
 background: rgb(2, 0, 36);
-background: linear-gradient(
-  90deg,
-  rgba(2, 0, 36, 1) 0%,
-  rgba(13, 232, 230, 1) 35%,
-  rgba(0, 212, 255, 1) 100%
-);
+background: linear-gradient(90deg, rgba(2, 0, 36, 1) 0%, rgba(13, 232, 230, 1) 35%, rgba(0, 212, 255, 1) 100%);
 ```
 
 ## CSS The Box Model
@@ -498,7 +498,10 @@ background: linear-gradient(
 }
 ```
 
-See also: [max-width](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width) / [min-width](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width) / [max-height](https://developer.mozilla.org/en-US/docs/Web/CSS/max-height) / [min-height](https://developer.mozilla.org/en-US/docs/Web/CSS/min-height)
+See also: [max-width](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width) /
+[min-width](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width) /
+[max-height](https://developer.mozilla.org/en-US/docs/Web/CSS/max-height) /
+[min-height](https://developer.mozilla.org/en-US/docs/Web/CSS/min-height)
 
 ### Margin / Padding
 
@@ -509,7 +512,8 @@ See also: [max-width](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width
 }
 ```
 
-See also: [Margin](https://developer.mozilla.org/en-US/docs/Web/CSS/margin) / [Padding](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
+See also: [Margin](https://developer.mozilla.org/en-US/docs/Web/CSS/margin) /
+[Padding](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
 
 ### Box-sizing
 
@@ -764,8 +768,7 @@ A fixed-height top bar and a dynamic-height content area.
 }
 ```
 
-This creates columns that have different widths, but size accordingly according
-to the circumstances.
+This creates columns that have different widths, but size accordingly according to the circumstances.
 
 ### Vertical
 

--- a/source/_posts/ejs.md
+++ b/source/_posts/ejs.md
@@ -12,6 +12,7 @@ intro:
   EJS(Embedded JavaScript) is a simple templating language that lets you generate HTML markup with plain JavaScript.
 plugins:
   - copyCode
+  - runCode
 ---
 
 <!-- NOTE: EJS does not have Prettier support, so manually format and add a prettier-ignore above broken code blocks -->
@@ -58,10 +59,11 @@ Pass EJS a template string and some data.
 ### Browser Support
 
 ```html
-<script src="ejs.js"></script>
+<script src="https://unpkg.com/ejs"></script>
 <script>
   let people = ["geddy", "neil", "alex"];
   let html = ejs.render('<%= people.join(", "); %>', { people: people });
+  console.log(html);
 </script>
 ```
 

--- a/source/_posts/es6.md
+++ b/source/_posts/es6.md
@@ -11,6 +11,7 @@ intro: |
   A quick reference cheatsheet of what's new in JavaScript for ES2015, ES2016, ES2017, ES2018 and beyond
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started

--- a/source/_posts/go.md
+++ b/source/_posts/go.md
@@ -10,6 +10,7 @@ intro: |
   This cheat sheet provided basic syntax and methods to help you using [Go](https://go.dev/).
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started

--- a/source/_posts/html.md
+++ b/source/_posts/html.md
@@ -10,6 +10,7 @@ intro: |
   This HTML quick reference cheat sheet lists the common HTML and HTML5 tags in readable layout.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started

--- a/source/_posts/perl.md
+++ b/source/_posts/perl.md
@@ -9,6 +9,7 @@ intro: |
   The perl quick reference cheat sheet that aims at providing help on writing basic syntax and methods.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started
@@ -36,7 +37,9 @@ $make install
 
 - Download either 32bit or 64bit version of installation.
 
-- Run the downloaded file by double-clicking it in Windows Explorer. This brings up the Perl install wizard, which is really easy to use. Just accept the default settings, wait until the installation is finished, and you're ready to roll!
+- Run the downloaded file by double-clicking it in Windows Explorer. This brings up the Perl install wizard, which is
+  really easy to use. Just accept the default settings, wait until the installation is finished, and you're ready to
+  roll!
 
 ### Macintosh Installation
 

--- a/source/_posts/php.md
+++ b/source/_posts/php.md
@@ -10,6 +10,7 @@ intro: |
   This [PHP](https://www.php.net/manual/en/) cheat sheet provides a reference for quickly looking up the correct syntax for the code you use most frequently.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started

--- a/source/_posts/react.md
+++ b/source/_posts/react.md
@@ -11,6 +11,7 @@ intro: |
   A React cheat sheet with the most important concepts, functions, methods, and more. A complete quick reference for beginners.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started
@@ -62,7 +63,7 @@ return (
 
 ```javascript
 import React from "react";
-export default function Weather(props) {
+function Weather(props) {
   if (props.temperature >= 20) {
     return (
       <p>
@@ -77,6 +78,8 @@ export default function Weather(props) {
     );
   }
 }
+
+export default () => <Weather city="New York" temperature={24} />;
 ```
 
 Note: A component must always return something.
@@ -140,14 +143,14 @@ Note: External components are found on npmjs.com and need to be imported first.
 ```javascript
 import React from "react";
 
-export default function Hello(props) {
+function Hello(props) {
   function fullName() {
     return `${props.firstName} ${props.lastName}`;
   }
   return <p>{fullName()}</p>;
 }
 
-<Hello firstName="Matt" lastName="Delac" />;
+export default () => <Hello firstName="Matt" lastName="Delac" />;
 ```
 
 ## Properties {.cols-2}
@@ -539,6 +542,7 @@ Note: Custom Hooks are reusable functions in React that contain logic shared acr
 to extract stateful logic from components into standalone functions.
 
 ### Creating Refs in Class Components
+
 ```javascript
 import React, { Component } from "react";
 
@@ -561,8 +565,8 @@ export default MyComponent;
 ```
 
 ### Using Refs in Functional Components
-```javascript
 
+```javascript
 import React, { useRef, useEffect } from "react";
 
 function MyComponent() {
@@ -579,15 +583,15 @@ export default MyComponent;
 ```
 
 ### Callback Refs
-```javascript
 
+```javascript
 import React, { Component } from "react";
 
 class MyComponent extends Component {
   constructor(props) {
     super(props);
     this.myRef = null;
-    this.setRef = element => {
+    this.setRef = (element) => {
       this.myRef = element;
     };
   }
@@ -605,6 +609,7 @@ export default MyComponent;
 ```
 
 ### Forwarding Refs
+
 ```javascript
 Copy code
 import React from "react";
@@ -621,10 +626,10 @@ const ref = React.createRef();
 ```
 
 ### Accessing DOM Elements with Refs
+
 ### Refs are often used to access and interact with DOM elements directly. Here's an example where we focus an input element using a ref:
 
 ```javascript
-
 import React, { useRef, useEffect } from "react";
 
 function FocusInput() {
@@ -642,10 +647,10 @@ export default FocusInput;
 ```
 
 ### Managing Focus with Refs
+
 ### You can also manage focus between multiple elements using refs:
 
 ```javascript
-
 import React, { useRef } from "react";
 
 function Form() {

--- a/source/_posts/ruby.md
+++ b/source/_posts/ruby.md
@@ -11,6 +11,7 @@ intro: |
   The [Ruby](https://www.ruby-lang.org/) cheat sheet is a one-page reference sheet for the Ruby programming language.
 plugins:
   - copyCode
+  - runCode
 ---
 
 ## Getting Started

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -86,6 +86,10 @@
             let language = [...codeBlock.classList].find(c => c.startsWith("language-"))?.replace("language-", "") || '';
 
             if (['', 'shell', 'bash'].includes(language)) return;
+            if (language === 'c' && content.includes('FILE ')) {
+                // file operations are not supported in the online playground
+                return;
+            }
 
             // Create a run button element
             const runButton = document.createElement('button');
@@ -106,7 +110,7 @@
                     language = 'javascript';
                 }
                 
-                const editorId = ['javascript', 'typescript', 'python', 'php', 'ruby', 'go', 'perl', 'cpp'].includes(language) 
+                const editorId = ['javascript', 'typescript', 'python', 'php', 'ruby', 'go', 'perl', 'cpp', 'c'].includes(language) 
                                     ? 'script' 
                                     : ['css', 'scss'].includes(language) 
                                         ? 'style' 
@@ -267,6 +271,9 @@
                             language,
                             content,
                         },
+                        tools: {
+                            status: 'full',
+                        }
                     }
                 }
 
@@ -291,6 +298,9 @@
                             language,
                             content,
                         },
+                        tools: {
+                            status: 'full',
+                        }
                     }
                 }
 
@@ -300,7 +310,7 @@
                             const freeCode = content.split('\n').filter(line => !line.startsWith('class ') && !line.startsWith('  ') && !line.startsWith('}')).join('\n');
                             content = `${content.replace(freeCode, '')}\nint main()\n{\n${freeCode.trim().split('\n').map(line => `  ${line}`).join('\n')}\n}`;
                         } else {                            
-                            content = `int main()\n{\n${content.trim().split('\n').map(line => `  ${line}`).join('\n')}\n\n    return 0;\n}\n`;
+                            content = `int main()\n{\n${content.trim().split('\n').map(line => `  ${line}`).join('\n')}\n\n  return 0;\n}\n`;
                         }
                     }
                     if (content.includes('std::') && !content.includes('#include')) {
@@ -323,6 +333,32 @@
                             language: 'cpp-wasm',
                             content,
                         },
+                        tools: {
+                            status: 'full',
+                        }
+                    }
+                }
+
+                if (language === 'c') {
+                    if (!content.includes('int main(') && !content.includes('void main(')) {
+                        content = `int main(void)\n{\n${content.trim().split('\n').map(line => `  ${line}`).join('\n')}\n\n  return 0;\n}\n`;
+                    }
+                    if ((content.includes('printf') || content.includes('scanf')) && !content.includes('#include <stdio.h>')) {
+                        content = `#include <stdio.h>\n\n${content}`;
+                    }
+                    if (content.includes('strcpy') && !content.includes('#include <string.h>')) {
+                        content = `#include <string.h>\n${content}`;
+                    }
+                    config = {
+                        ...baseConfig,
+                        script: {
+                            language: 'cpp-wasm',
+                            title: 'C (Wasm)',
+                            content,
+                        },
+                        tools: {
+                            status: 'full',
+                        }
                     }
                 }
 

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -81,7 +81,7 @@
         const code_Blocks = document.querySelectorAll('pre > code');
         const runInnerHTML = '<svg height="1em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g stroke-width="0"></g><g stroke-linecap="round" stroke-linejoin="round"></g><g><path d="M16.6582 9.28638C18.098 10.1862 18.8178 10.6361 19.0647 11.2122C19.2803 11.7152 19.2803 12.2847 19.0647 12.7878C18.8178 13.3638 18.098 13.8137 16.6582 14.7136L9.896 18.94C8.29805 19.9387 7.49907 20.4381 6.83973 20.385C6.26501 20.3388 5.73818 20.0469 5.3944 19.584C5 19.053 5 18.1108 5 16.2264V7.77357C5 5.88919 5 4.94701 5.3944 4.41598C5.73818 3.9531 6.26501 3.66111 6.83973 3.6149C7.49907 3.5619 8.29805 4.06126 9.896 5.05998L16.6582 9.28638Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"></path></g></svg>';
         code_Blocks.forEach(function (codeBlock) {
-            let content = codeBlock.textContent;
+            let content = codeBlock.textContent || '';
             let language = [...codeBlock.classList].filter(c => c.startsWith("language-"))[0].replace("language-", "");
 
             if (language === 'shell') return;
@@ -102,7 +102,7 @@
                     language = 'typescript';
                 }
                 
-                const editorId = ['javascript', 'typescript', 'python'].includes(language) 
+                const editorId = ['javascript', 'typescript', 'python', 'php'].includes(language) 
                                     ? 'script' 
                                     : ['css', 'scss'].includes(language) 
                                         ? 'style' 
@@ -178,6 +178,23 @@
                         markup: {
                             language: 'html',
                             content: `<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></scr` + 'ipt>\n',
+                        },
+                        tools: {
+                            status: 'closed',
+                        }
+                    }
+                }
+
+                if (['php'].includes(language)) {
+                    config = {
+                        ...baseConfig,
+                        style: {
+                            language: 'css',
+                            content: 'body { white-space: pre-wrap; }\n',
+                        },
+                        script: {
+                            language: 'php-wasm',
+                            content: !content.trim().startsWith('<?php') ? `<?php\n\n${content.trim()}\n\n?>` : content,
                         },
                         tools: {
                             status: 'closed',

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -102,8 +102,11 @@
                 if (language === 'ts') {
                     language = 'typescript';
                 }
+                if (language === 'js') {
+                    language = 'javascript';
+                }
                 
-                const editorId = ['js', 'javascript', 'typescript', 'python', 'php', 'ruby', 'perl'].includes(language) 
+                const editorId = ['javascript', 'typescript', 'python', 'php', 'ruby', 'perl'].includes(language) 
                                     ? 'script' 
                                     : ['css', 'scss'].includes(language) 
                                         ? 'style' 
@@ -204,6 +207,26 @@
                             "template": {
                                 "prerender": false,
                             },
+                        },
+                    }
+                }
+
+                if (language === 'javascript' && pageHeader.startsWith('HTML Canvas')) {
+                    if (!content.includes('const ctx =')) {
+                        content = `const canvas = document.getElementById("myCanvas");\nconst ctx = canvas.getContext("2d");\n\n${content}`;
+                    }
+                    config = {
+                        ...baseConfig,
+                        markup: {
+                            language: 'html',
+                            content: "<canvas id=\"myCanvas\" width=\"500\" height=\"400\" style=\"border:1px solid #000000;\"></canvas>\n",
+                        },
+                        script: {
+                            language,
+                            content,
+                        },
+                        tools: {
+                            status: 'closed',
                         },
                     }
                 }

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -102,7 +102,7 @@
                     language = 'typescript';
                 }
                 
-                const editorId = ['javascript', 'typescript', 'python', 'php'].includes(language) 
+                const editorId = ['js', 'javascript', 'typescript', 'python', 'php'].includes(language) 
                                     ? 'script' 
                                     : ['css', 'scss'].includes(language) 
                                         ? 'style' 

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -75,6 +75,7 @@
 
 
 <% if (is_post() && page.plugins != undefined && page.plugins.includes("runCode") ){ %>
+    <!-- see https://livecodes.io/docs/ and https://livecodes.io/docs/sdk -->
     <script src="https://cdn.jsdelivr.net/npm/livecodes@0.7.2/livecodes.umd.js"></script>
     <script>
         // Get all pre > code elements
@@ -117,6 +118,7 @@
                                         : 'markup';
                 const title = codeBlock.closest('.h3-wrap')?.querySelector('h3')?.textContent.replace('#', '') || '';
 
+                // see docs for configuration object: https://livecodes.io/docs/configuration/configuration-object
                 const baseConfig = {
                     title,
                     activeEditor: editorId,
@@ -180,6 +182,7 @@
                     }
                 }
 
+                // see https://livecodes.io/docs/languages/ejs
                 if (language === 'html' && pageHeader.startsWith('EJS')) {
                     config = {
                         ...baseConfig,
@@ -222,6 +225,8 @@
                     }
                 }
 
+                // see https://livecodes.io/docs/languages/jsx
+                // and https://livecodes.io/docs/languages/react
                 if (language === 'javascript' && pageHeader.startsWith('React')) {
                     config = {
                         ...baseConfig,
@@ -237,6 +242,8 @@
                     }
                 }
 
+                // see https://livecodes.io/docs/languages/php-wasm
+                // and https://livecodes.io/docs/languages/php
                 if (language === 'php') {
                     config = {
                         ...baseConfig,
@@ -254,6 +261,8 @@
                     }
                 }
 
+                // see https://livecodes.io/docs/languages/python
+                // and https://livecodes.io/docs/languages/python-wasm
                 if (language === 'python') {
                     if (content.includes('>>> ')) {
                         content = content
@@ -362,7 +371,12 @@
                     }
                 }
 
-                const plaugroundUrl = livecodes.getPlaygroundUrl({config});
+                // see https://livecodes.io/docs/sdk/js-ts#getplaygroundurl
+                const plaugroundUrl = livecodes.getPlaygroundUrl({
+                    // see https://livecodes.io/docs/features/permanent-url/
+                    appUrl: 'https://v39.livecodes.io',
+                    config,
+                });
                 window.open(plaugroundUrl, '_blank');
             });
 

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -106,25 +106,12 @@
                     language = 'javascript';
                 }
                 
-                const editorId = ['javascript', 'typescript', 'python', 'php', 'ruby', 'perl'].includes(language) 
+                const editorId = ['javascript', 'typescript', 'python', 'php', 'ruby', 'go', 'perl'].includes(language) 
                                     ? 'script' 
                                     : ['css', 'scss'].includes(language) 
                                         ? 'style' 
                                         : 'markup';
                 const title = codeBlock.closest('.h3-wrap')?.querySelector('h3')?.textContent.replace('#', '') || '';
-
-                if (language === 'python') {
-                    if (content.includes('>>> ')) {
-                        content = content
-                            .trim()
-                            .split('\n')
-                            .map(line => line.startsWith('>>> ') ? line.replace('>>> ', '') : `# ${line}`)
-                            .join('\n');
-                    }
-                    if (content.includes('from typing import')) {
-                        language = 'python-wasm';
-                    }
-                }
 
                 const baseConfig = {
                     title,
@@ -246,7 +233,7 @@
                     }
                 }
 
-                if (['php'].includes(language)) {
+                if (language === 'php') {
                     config = {
                         ...baseConfig,
                         style: {
@@ -260,6 +247,51 @@
                         tools: {
                             status: 'closed',
                         }
+                    }
+                }
+
+                if (language === 'python') {
+                    if (content.includes('>>> ')) {
+                        content = content
+                            .trim()
+                            .split('\n')
+                            .map(line => line.startsWith('>>> ') ? line.replace('>>> ', '') : `# ${line}`)
+                            .join('\n');
+                    }
+                    if (content.includes('from typing import')) {
+                        language = 'python-wasm';
+                    }
+                    config = {
+                        ...baseConfig,
+                        script: {
+                            language,
+                            content,
+                        },
+                    }
+                }
+
+                if (language === 'go') {
+                    if (!content.includes('func main() {') && !content.includes('import')) {
+                        if (content.includes('func ')) {
+                            const freeCode = content.split('\n').filter(line => !line.startsWith('func ') && !line.startsWith('  ') && !line.startsWith('}')).join('\n');
+                            content = `${content.replace(freeCode, '')}\nfunc main() {\n${freeCode.trim().split('\n').map(line => `    ${line}`).join('\n')}\n}`;
+                        } else {
+                            content = `func main() {\n${content.trim().split('\n').map(line => `    ${line}`).join('\n')}\n}`;
+                        }
+                    }
+
+                    if (content.includes('fmt.') && !content.includes('import')) {
+                        content = `import "fmt"\n\n${content}`
+                    }
+                    if (!content.includes('package main')) {
+                        content = `package main\n\n${content}`
+                    }
+                    config = {
+                        ...baseConfig,
+                        script: {
+                            language,
+                            content,
+                        },
                     }
                 }
 

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -83,9 +83,9 @@
         const pageHeader = (document.querySelector('h1')?.textContent || '').trim();
         code_Blocks.forEach(function (codeBlock) {
             let content = codeBlock.textContent || '';
-            let language = [...codeBlock.classList].filter(c => c.startsWith("language-"))[0].replace("language-", "");
+            let language = [...codeBlock.classList].find(c => c.startsWith("language-"))?.replace("language-", "") || '';
 
-            if (['shell', 'bash'].includes(language)) return;
+            if (['', 'shell', 'bash'].includes(language)) return;
 
             // Create a run button element
             const runButton = document.createElement('button');
@@ -106,7 +106,7 @@
                     language = 'javascript';
                 }
                 
-                const editorId = ['javascript', 'typescript', 'python', 'php', 'ruby', 'go', 'perl'].includes(language) 
+                const editorId = ['javascript', 'typescript', 'python', 'php', 'ruby', 'go', 'perl', 'cpp'].includes(language) 
                                     ? 'script' 
                                     : ['css', 'scss'].includes(language) 
                                         ? 'style' 
@@ -279,7 +279,6 @@
                             content = `func main() {\n${content.trim().split('\n').map(line => `    ${line}`).join('\n')}\n}`;
                         }
                     }
-
                     if (content.includes('fmt.') && !content.includes('import')) {
                         content = `import "fmt"\n\n${content}`
                     }
@@ -290,6 +289,38 @@
                         ...baseConfig,
                         script: {
                             language,
+                            content,
+                        },
+                    }
+                }
+
+                if (language === 'cpp') {
+                    if (!content.includes('int main()')) {
+                        if (content.includes('class ')) {
+                            const freeCode = content.split('\n').filter(line => !line.startsWith('class ') && !line.startsWith('  ') && !line.startsWith('}')).join('\n');
+                            content = `${content.replace(freeCode, '')}\nint main()\n{\n${freeCode.trim().split('\n').map(line => `  ${line}`).join('\n')}\n}`;
+                        } else {                            
+                            content = `int main()\n{\n${content.trim().split('\n').map(line => `  ${line}`).join('\n')}\n\n    return 0;\n}\n`;
+                        }
+                    }
+                    if (content.includes('std::') && !content.includes('#include')) {
+                        content = '\n' + content;
+                        if (content.includes('std::array') && !content.includes('#include <array>')) {
+                            content = `#include <array>\n${content}`;
+                        }
+                        if (content.includes('std::string') && !content.includes('#include <string>')) {
+                            content = `#include <string>\n${content}`;
+                        }
+                        if (content.includes('std::cout') && !content.includes('#include <iostream>')) {
+                            content = `#include <iostream>\n${content}`;
+                        }
+                    } else if (content.includes('cout') && !content.includes('#include <iostream>')) {
+                        content = `#include <iostream>\nusing namespace std;\n\n${content}`;
+                    }
+                    config = {
+                        ...baseConfig,
+                        script: {
+                            language: 'cpp-wasm',
                             content,
                         },
                     }

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -103,7 +103,7 @@
                     language = 'typescript';
                 }
                 
-                const editorId = ['js', 'javascript', 'typescript', 'python', 'php', 'ruby'].includes(language) 
+                const editorId = ['js', 'javascript', 'typescript', 'python', 'php', 'ruby', 'perl'].includes(language) 
                                     ? 'script' 
                                     : ['css', 'scss'].includes(language) 
                                         ? 'style' 

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -185,6 +185,28 @@
                     }
                 }
 
+                if (language === 'html' && document.querySelector('h1').textContent.includes('EJS')) {
+                    config = {
+                        ...baseConfig,
+                        markup: {
+                            language: 'ejs',
+                            content,
+                        },
+                        script: {
+                            language: 'javascript',
+                            content: "window.livecodes.templateData = {\n  userLoggedIn: false,\n  user: { username: 'geddy', email: 'geddy@example.com' },\n  users: [\n    { username: 'geddy', email: 'geddy@example.com' },\n    { username: 'neil', email: 'neil@example.com' },\n    { username: 'alex', email: 'alex@example.com' },\n  ],\n};\n",
+                        },
+                        tools: {
+                            status: 'open',
+                        },
+                        customSettings: {
+                            "template": {
+                                "prerender": false,
+                            },
+                        },
+                    }
+                }
+
                 if (['php'].includes(language)) {
                     config = {
                         ...baseConfig,

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -104,7 +104,7 @@
                 
                 const editorId = ['javascript', 'typescript', 'python'].includes(language) 
                                     ? 'script' 
-                                    : ['scss'].includes(language) 
+                                    : ['css', 'scss'].includes(language) 
                                         ? 'style' 
                                         : 'markup';
                 const title = codeBlock.closest('.h3-wrap')?.querySelector('h3')?.textContent.replace('#', '') || '';
@@ -149,6 +149,15 @@
                         tools: {
                             status: 'open',
                             active: 'compiled',
+                        }
+                    }
+                }
+
+                if (['html', 'css'].includes(language)) {
+                    config = {
+                        ...baseConfig,
+                        tools: {
+                            status: 'closed',
                         }
                     }
                 }

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -80,6 +80,7 @@
         // Get all pre > code elements
         const code_Blocks = document.querySelectorAll('pre > code');
         const runInnerHTML = '<svg height="1em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g stroke-width="0"></g><g stroke-linecap="round" stroke-linejoin="round"></g><g><path d="M16.6582 9.28638C18.098 10.1862 18.8178 10.6361 19.0647 11.2122C19.2803 11.7152 19.2803 12.2847 19.0647 12.7878C18.8178 13.3638 18.098 13.8137 16.6582 14.7136L9.896 18.94C8.29805 19.9387 7.49907 20.4381 6.83973 20.385C6.26501 20.3388 5.73818 20.0469 5.3944 19.584C5 19.053 5 18.1108 5 16.2264V7.77357C5 5.88919 5 4.94701 5.3944 4.41598C5.73818 3.9531 6.26501 3.66111 6.83973 3.6149C7.49907 3.5619 8.29805 4.06126 9.896 5.05998L16.6582 9.28638Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"></path></g></svg>';
+        const pageHeader = (document.querySelector('h1')?.textContent || '').trim();
         code_Blocks.forEach(function (codeBlock) {
             let content = codeBlock.textContent || '';
             let language = [...codeBlock.classList].filter(c => c.startsWith("language-"))[0].replace("language-", "");
@@ -172,7 +173,7 @@
                     }
                 }
 
-                if (document.querySelector('h1').textContent.includes('jQuery')) {
+                if (pageHeader.startsWith('jQuery')) {
                     config = {
                         ...baseConfig,
                         markup: {
@@ -185,7 +186,7 @@
                     }
                 }
 
-                if (language === 'html' && document.querySelector('h1').textContent.includes('EJS')) {
+                if (language === 'html' && pageHeader.startsWith('EJS')) {
                     config = {
                         ...baseConfig,
                         markup: {
@@ -202,6 +203,21 @@
                         customSettings: {
                             "template": {
                                 "prerender": false,
+                            },
+                        },
+                    }
+                }
+
+                if (language === 'javascript' && pageHeader.startsWith('React')) {
+                    config = {
+                        ...baseConfig,
+                        script: {
+                            language: 'jsx',
+                            content,
+                        },
+                        customSettings: {
+                            imports: {
+                                'axios': 'https://cdn.skypack.dev/axios',
                             },
                         },
                     }

--- a/themes/coo/layout/_partial/scripts.ejs
+++ b/themes/coo/layout/_partial/scripts.ejs
@@ -85,7 +85,7 @@
             let content = codeBlock.textContent || '';
             let language = [...codeBlock.classList].filter(c => c.startsWith("language-"))[0].replace("language-", "");
 
-            if (language === 'shell') return;
+            if (['shell', 'bash'].includes(language)) return;
 
             // Create a run button element
             const runButton = document.createElement('button');
@@ -103,7 +103,7 @@
                     language = 'typescript';
                 }
                 
-                const editorId = ['js', 'javascript', 'typescript', 'python', 'php'].includes(language) 
+                const editorId = ['js', 'javascript', 'typescript', 'python', 'php', 'ruby'].includes(language) 
                                     ? 'script' 
                                     : ['css', 'scss'].includes(language) 
                                         ? 'style' 


### PR DESCRIPTION
This is a follow up PR after the previous one #628 , as discussed in the issue #626 

The previous PR added support to run:
- JavaScript
- TypeScript
- Python
- Markdown
- Sass
- jQuery

This PR adds:
- HTML
- HTML Canvas
- CSS
- ES6
- React
- EJS
- PHP
- Ruby
- Go
- C
- C++
- Perl

Total 18 (languages/libraries).

I had to manipulate the code for some languages to allow it to run (e.g. adding main function, adding imports, etc.)

Please let me know if you have any comments.