### PR TITLE
docs(yaml): fix typo for serialization

### DIFF
--- a/source/_posts/yaml.md
+++ b/source/_posts/yaml.md
@@ -17,7 +17,7 @@ plugins:
 
 ### Introduction
 
-[YAML](https://yaml.org/) is a data serialisation language designed to be directly writable and readable by humans
+[YAML](https://yaml.org/) is a data serialization language designed to be directly writable and readable by humans
 
 - YAML does not allow the use of tabs
 - Must be space between the element parts


### PR DESCRIPTION
This PR simply aims to resolve a typo for the word `serialisation` in the YAML cheatsheet.