### PR TITLE
Fix Duplicate Refs Section in React Cheatsheet

### DIFF
--- a/source/_posts/react.md
+++ b/source/_posts/react.md
@@ -627,8 +627,6 @@ const ref = React.createRef();
 
 ### Accessing DOM Elements with Refs
 
-### Refs are often used to access and interact with DOM elements directly. Here's an example where we focus an input element using a ref:
-
 ```javascript
 import React, { useRef, useEffect } from "react";
 
@@ -645,10 +643,9 @@ function FocusInput() {
 
 export default FocusInput;
 ```
+Note: Refs are often used to access and interact with DOM elements directly. Here's an example where we focus an input element using a ref.
 
 ### Managing Focus with Refs
-
-### You can also manage focus between multiple elements using refs:
 
 ```javascript
 import React, { useRef } from "react";
@@ -673,3 +670,4 @@ function Form() {
 
 export default Form;
 ```
+Note: You can also manage focus between multiple elements using refs.


### PR DESCRIPTION
#### This PR resolves an issue in the Refs section of the React cheatsheet where the "Accessing DOM Elements with Refs" and "Managing Focus with Refs" examples were duplicated and displayed out of alignment.

### 🔍 Before

#### Section
![Image](https://github.com/user-attachments/assets/ea910566-9e58-4515-abe3-8ab696d31b8b)

![Image](https://github.com/user-attachments/assets/dec79776-8318-4b66-a556-77d2060a4094)

#### Issue :
- Duplicate entries of both examples
- UI misalignment with empty blocks
- Some explanatory text is cut or incomplete


### ✅ After
#### Section	
![Image](https://github.com/user-attachments/assets/f8ee3c42-6eff-4f0c-accc-6c5dd99fcb40)


#### Fix :
- Removed duplicated content
- Aligned examples side-by-side correctly
- Ensured both examples have complete text blocks and working code UI

### 🧪 Testing
 Code renders correctly in cheatsheet preview

 Ref functionality works as expected in live preview

 No duplicate elements found