### PR TITLE
fix typo: "et" → "let"

### DIFF
--- a/source/_posts/nim.md
+++ b/source/_posts/nim.md
@@ -103,7 +103,7 @@ Basic data types
 ### Integers
 
 ```nim
-et
+let
   a = 11
   b = 4
 


### PR DESCRIPTION
Corrected a small typo in `nim.md` where let was misspelled as et.