### PR TITLE
Added content to Chatgpt

### DIFF
--- a/source/_posts/chatgpt.md
+++ b/source/_posts/chatgpt.md
@@ -75,59 +75,94 @@ Privacy And Security
 
 ## Prompt Engineering
 ### Prompt Frameworks
-Only use prompt components that are relevant for your needs.
-~~~
 General Purpose
+~~~
 [role] [task] [tone] [format] [restriction]
 ~~~
+- Only use prompt components that are relevant for your needs.
 
 ### Role
 Standard
 - Act as [occupation]
 
-Common Standard Roles
+Common Roles
 - Personal Coach
 - Consultant
 - Entrepreneur
 - Proofreader
 - Therapist
 
-Also See
+List Of Roles
 - [Awesome ChatGPT Prompts](https://github.com/f/awesome-chatgpt-prompts) _(github.com)_
 
 Roleplay
 - Act as [figure] with [appearance] [personality] [behaviour examples] [lore] in [scenario]
 
-### Task
+### Task (5Ws & H)
+[verb] [task] [specifics]
+
+Who
+- Who is X?
+- Who is [involved | affected | responsible] for X?
+- Who should I contact for help with X?
+
+What
+- [What is | define | explain | describe] X?
+- What did [entity | text] mean by [quote]?
+- What events led up to [event]?
+- What [assumptions | risks | constraints] exist for X?
+- What are the critical features of X?
+- What is done well?
+- What can be improved?
+- What is the [best | most efficient] way to do X?
+
+When
+- When [did | will] [entity | event] occur?
+- When is X due?
+- When is the best time to initiate X?
+
+Where
+- Where did [entity | event] happen?
+- [Where to find X? | where to find resources about X? | suggest websites about X]
+
+Why
+- Why did [entity] choose [approach]?
+- Why [did | will] [event] occur?
+- Why is [approach] being implemented?
+- Why might X succeed or fail?
+- Why is [solution] preferable to [alternative]?
+- Why is it important?
+
+How
+- How to do [task | process]?
+- How does X work?
+- How does X do Y?
+- How to measure [metric] accurately?
+
+### Task (CRUD Operations)
 [verb] [task] [specifics]
 
 Create
-- [Write content about X|suggest ideas about X|suggest titles about X]
-- Write content about X in the style of [style]
+- Content type examples: title, article, guide, essay, outline, email, social media post, description, SEO keywords, video script, recipe, analysis, program
+- Write [content type] about [topic]
+- Write [content type] to [entity] about [topic]
+- [Continue | expand]
+- Show example
 - Write better
-- Write email to [entity] about X
-- [Continue|expand]
-- [Explain how to do X|create roadmap for X]
-- [Suggest best practices for X|suggest improvements|what am I doing right?|what am I doing wrong?]
-- Show list of emojis about X
-- [Create|generate|imagine] image about X
+- Create image of X
 
 Read
-- [Summarise|write concise main points]
-- [Explain|elaborate]
-- Explain what [entity|text] meant by X
-- Identify themes in X
-- Write outline about X
-- Extract keywords
-- Get up-to-date [facts|news|data] on X
+- [Explain | elaborate]
+- [Summarise | write main points]
+- Identify [themes | keywords] in X
+- Get up-to-date [facts | news | data] on X
 - Is this true?
-- Suggest [media] [about|similar to] X
-- Pick best from [options]
+- Suggest [media type] [about | similar to] X
 
 Update
 - For all X do [action]
 - For X do [action] if matching [criteria]
-- Reformat everything as [format]
+- Reformat as [format]
 
 Delete
 - Delete [quantity] of X matching [criteria]
@@ -135,28 +170,32 @@ Delete
 - Delete [item] [number]
 - Delete duplicate items from X
 
+### Task (Other)
+[verb] [task] [specifics]
+
 Compare
-- Identify [simlarities|diffirences] between X and Y
+- Identify [simlarities | diffirences] between X and Y
 - Identify gaps in X
-- Evaluate pros and cons of X
-- X [comparison operator] Y. It could be abstractly expressed as "are apples bigger than walnuts?"
+- Identify pros and cons of X
+- X [comparison operator] Y
 
 Filter
 - Filter X by [criteria]
-- Exclude X by [criteria]. Everything is excluded by default.
+- Exclude X by [criteria]
 
-Select
-- Select [quantity] of X based on [criteria|randomly]
+Choose
+- Choose [quantity] of X based on [criteria | randomly]
+- Choose best from [options]
 
 Simplify
-- Explain X like I’m 5
-- Explain in simple terms
+- [Explain X like I’m 5 | explain in simple terms]
 
 Sort
-- Sort X by [key] in [alphabetical|chronological|ascending|descending|lexicographical|custom] order
+- Sort order examples: alphabetical, chronological, ascending, descending, lexicographical, custom
+- Sort X by [key] in [order]
 
 Translate
-- Translate into [language]. For programming languages it's specifically called transpile
+- Translate into [language]
 
 ### Tone
 Using [tone] tone
@@ -189,15 +228,15 @@ Negative Tones
 - Sarcastic
 - Urgent
 
-### Format
+### Format (Text)
 In [format]
 
-Presentation
-- Plain text
+List
 - Bullet point list
 - Numbered list
-- Table
-- Code snippet
+
+Code
+- Code
 
 Process
 - Step-by-step instructions
@@ -207,15 +246,38 @@ Response
 - Dialogue
 
 Creative
-- Poetry
-- Music lyrics
 - Script
 - Comic strip dialogue
+- Poetry
+- Music lyrics
+- Riddle
 
 Game
 - Quiz
 - RPG
 - Choose-Your-Own-Adventure
+
+File Format
+- Plain text
+- Markdown
+- CSV
+- XML
+- JSON
+
+### Format (Visual)
+In [format]
+
+Data Visualization
+- Table
+- Chart types: gantt, bubble, error, contour, area, scatter, KDE, box, histogram, bar, line, 3D, joint, surface, polar, pie, cat, pair, strip, swarm, heatmap, hexbin
+- [Chart] chart
+
+Creative
+- Emojis
+- Word cloud
+
+File Format
+- PDF (supports both text and images)
 
 ### Restriction
 But [restriction]
@@ -236,10 +298,10 @@ Structural Constraints
 
 Content Constraints
 - Don't change the wording
-- Only minor edits
+- Permit [minor | major] edits
+- Use pop culture references
 - Ensure goals align with SMART criteria
-- Only show content that has changed
-- Avoid discussing sensitive topics (e.g., death, rape, war)
+- Only show [changed | unchanged] content
 
 ## Examples
 ### Job
@@ -693,8 +755,8 @@ Scenario:
 -	Lead actor is missing and staff are stressing out how to pull off the performance.
 ```
 
-## Any Suggestions?
-- [💡 I Got an IDEA](https://github.com/Fechin/reference/blob/main/source/_posts/chatgpt.md)
+# Partial References
+- https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/2b88d101-e659-4adc-a63a-560b2b70179a/_FINAL__The_ChatGPT_Cheat_Sheet__1_.png
 
 <style>
 em { font-size: 0.785em; }

--- a/source/_posts/chatgpt.md
+++ b/source/_posts/chatgpt.md
@@ -756,10 +756,10 @@ Scenario:
 -	Lead actor is missing and staff are stressing out how to pull off the performance.
 ```
 
-# Partial References
-- https://www.linkedin.com/posts/denis-panjuta_the-ultimate-chatgpt-40-guide-roles-activity-7231208824680976384-bdlY/
-- https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/2b88d101-e659-4adc-a63a-560b2b70179a/_FINAL__The_ChatGPT_Cheat_Sheet__1_.png
-- https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/0a928290-8e99-414e-b847-5b2dff35ec55/ChatGPT_-_Code_Interpreter_In_a_Nutshell___1_.png
+## Partial References
+- [General Purpose Framework](https://www.linkedin.com/posts/denis-panjuta_the-ultimate-chatgpt-40-guide-roles-activity-7231208824680976384-bdlY/)
+- [General Info](https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/2b88d101-e659-4adc-a63a-560b2b70179a/_FINAL__The_ChatGPT_Cheat_Sheet__1_.png)
+- [Data Visualization](https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/0a928290-8e99-414e-b847-5b2dff35ec55/ChatGPT_-_Code_Interpreter_In_a_Nutshell___1_.png)
 
 <style>
 em { font-size: 0.785em; }

--- a/source/_posts/chatgpt.md
+++ b/source/_posts/chatgpt.md
@@ -79,6 +79,7 @@ General Purpose
 ~~~
 [role] [task] [tone] [format] [restriction]
 ~~~
+
 - Only use prompt components that are relevant for your needs.
 
 ### Role
@@ -98,7 +99,7 @@ List Of Roles
 Roleplay
 - Act as [figure] with [appearance] [personality] [behaviour examples] [lore] in [scenario]
 
-### Task (5Ws & H)
+### Task (5Ws And H)
 [verb] [task] [specifics]
 
 Who
@@ -144,6 +145,7 @@ How
 
 Create
 - Content type examples: title, article, guide, essay, outline, email, social media post, description, SEO keywords, video script, recipe, analysis, program
+- Reverse engineer X
 - Write [content type] about [topic]
 - Write [content type] to [entity] about [topic]
 - [Continue | expand]
@@ -283,16 +285,15 @@ File Format
 But [restriction]
 
 Length Constraints
-- Concise
-- In N words
-- In N sentences
+- Be [extremely detailed | concise]
+- [In N words | in N sentences]
 
 Language Constraints
 -	No jargon or technical terms
 
 Structural Constraints
 - Show N options
--	No examples
+-	Show N examples
 -	No headers
 -	No pretext titles
 
@@ -756,7 +757,9 @@ Scenario:
 ```
 
 # Partial References
+- https://www.linkedin.com/posts/denis-panjuta_the-ultimate-chatgpt-40-guide-roles-activity-7231208824680976384-bdlY/
 - https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/2b88d101-e659-4adc-a63a-560b2b70179a/_FINAL__The_ChatGPT_Cheat_Sheet__1_.png
+- https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/0a928290-8e99-414e-b847-5b2dff35ec55/ChatGPT_-_Code_Interpreter_In_a_Nutshell___1_.png
 
 <style>
 em { font-size: 0.785em; }

--- a/source/_posts/chatgpt.md
+++ b/source/_posts/chatgpt.md
@@ -109,13 +109,14 @@ Who
 
 What
 - [What is | define | explain | describe] X?
+- What does X do?
 - What did [entity | text] mean by [quote]?
 - What events led up to [event]?
 - What [assumptions | risks | constraints] exist for X?
 - What are the critical features of X?
-- What is done well?
-- What can be improved?
+- [What is done well? What can be improved?]
 - What is the [best | most efficient] way to do X?
+- What are the top 5 X for Y?
 
 When
 - When [did | will] [entity | event] occur?
@@ -136,6 +137,7 @@ Why
 
 How
 - How to do [task | process]?
+- How do I X?
 - How does X work?
 - How does X do Y?
 - How to measure [metric] accurately?
@@ -144,19 +146,20 @@ How
 [verb] [task] [specifics]
 
 Create
-- Content type examples: title, article, guide, essay, outline, email, social media post, description, SEO keywords, video script, recipe, analysis, program
-- Reverse engineer X
+- Content type examples: analysis, article, description, documentation, dummy data, email, essay, guide, outline, program, recipe, SEO keywords, social media post, study plan, title, video script.
 - Write [content type] about [topic]
 - Write [content type] to [entity] about [topic]
-- [Continue | expand]
-- Show example
+- Create [example | analogy]
+- Reverse engineer X
 - Write better
+- [Continue | expand]
 - Create image of X
 
 Read
+- [Summarise | key takeaways | write main points]
 - [Explain | elaborate]
-- [Summarise | write main points]
-- Identify [themes | keywords] in X
+- Extract [themes | keywords | info about X] in Y
+- Proofread for [spelling | grammar | punctuation ] errors
 - Get up-to-date [facts | news | data] on X
 - Is this true?
 - Suggest [media type] [about | similar to] X
@@ -165,6 +168,7 @@ Update
 - For all X do [action]
 - For X do [action] if matching [criteria]
 - Reformat as [format]
+- Categorise
 
 Delete
 - Delete [quantity] of X matching [criteria]
@@ -197,7 +201,12 @@ Sort
 - Sort X by [key] in [order]
 
 Translate
-- Translate into [language]
+- Translate [human language A] into [human language B| emojis]
+- Translate [programming language A] into [programming language B]
+- Convert [narrative voice A] to [narrative voice B]
+
+Trivia
+- Give questions about X
 
 ### Tone
 Using [tone] tone
@@ -298,6 +307,7 @@ Structural Constraints
 -	No pretext titles
 
 Content Constraints
+- Use [first-person | second-person | third-person] narrative voice
 - Don't change the wording
 - Permit [minor | major] edits
 - Use pop culture references
@@ -393,9 +403,10 @@ Add class "header" to header tag
 Update CSS to change font color to blue
 ```
 
-Transpile
+Translate
+- Specifically called transpile when addressing programming languages.
 ```{.wrap}
-Transpile code to Python
+Translate code to Python
 ```
 
 ### Email
@@ -756,10 +767,11 @@ Scenario:
 -	Lead actor is missing and staff are stressing out how to pull off the performance.
 ```
 
-## Partial References
+## References (Used For Ideas)
 - [General Purpose Framework](https://www.linkedin.com/posts/denis-panjuta_the-ultimate-chatgpt-40-guide-roles-activity-7231208824680976384-bdlY/)
 - [General Info](https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/2b88d101-e659-4adc-a63a-560b2b70179a/_FINAL__The_ChatGPT_Cheat_Sheet__1_.png)
 - [Data Visualization](https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/0a928290-8e99-414e-b847-5b2dff35ec55/ChatGPT_-_Code_Interpreter_In_a_Nutshell___1_.png)
+- [Comprehensive Cheatsheet](https://github.com/bg-write/chatGPT-cheatsheet)
 
 <style>
 em { font-size: 0.785em; }


### PR DESCRIPTION
Key changes
- Split task and format sections into sub-categories for clarity.
- Added 5Ws And H question command ideas.
- Added commands to various sections.
- Added missing references used for ideas.
- Grouped, shortened, and split commands for clarity.
- Used better verb prefix where necessary to more clearly convey command intention.
- Minor header fixes (accidentally joined to another piece of text or wrong formatting).