### PR TITLE
Fix: link to Chinese version should not be broken

### DIFF
--- a/themes/coo/layout/_partial/footer.ejs
+++ b/themes/coo/layout/_partial/footer.ejs
@@ -13,7 +13,7 @@
                 <%- partial('index/logo', {icon: false}) %>
                 <h4 class="mt-5 text-sm text-slate-500"><%- config.description %>.</h4>
                 <div class="share mt-4">
-                    <a href="/zh-CN/">中文版</a>
+                    <a href="https://wangchujiang.com/reference/">中文版</a>
                     <% if (site.posts.filter(post => post.layout === "note").length > 0) { %>
                         <a href="/notes/">#Notes</a>
                     <% } %>


### PR DESCRIPTION
The link to the Chinese version (中文版) on the main page is broken. It links to a non-existent `/zh-CN/` path.

The main Chinese fork of this project is https://wangchujiang.com/reference/. At least as far as I can tell - it was created explicitly to translate https://cheatsheets.zip/ and has the appropriate link-backs. Although the the code-bases have clearly diverged, it still seems to be the most appropriate link to use.

I have updated the link accordingly. 
