### PR TITLE
fix: use 'brew command --cask' instead of deprecated 'brew cask'

### DIFF
--- a/source/_posts/homebrew.md
+++ b/source/_posts/homebrew.md
@@ -143,7 +143,7 @@ brew tap homebrew/cask
 List all the installed casks .
 
 ```bash
-brew cask list
+brew list --cask
 ```
 
 Search all known casks based on the substring text.
@@ -155,19 +155,19 @@ brew search <text>
 Install the given cask.
 
 ```bash
-brew cask install <cask>
+brew install --cask <cask>
 ```
 
 Reinstalls the given Cask
 
 ```bash
-brew cask reinstall <cask>
+brew reinstall --cask <cask>
 ```
 
 Uninstall the given cask.
 
 ```bash
-brew cask uninstall <cask>
+brew uninstall --cask <cask>
 ```
 
 ### Search, Install, Remove


### PR DESCRIPTION
Addresses the error: "'brew cask' is no longer a 'brew' command. Use 'brew <command> --cask' instead."