### PR TITLE
fix: invisible text in AI cheatsheet

### DIFF
--- a/themes/coo/source/css/components/layout_list.css
+++ b/themes/coo/source/css/components/layout_list.css
@@ -123,6 +123,10 @@
   @apply fadeIn no-underline;
 }
 
+.mdLayout .h3-wrap > .section > ul.icon-list > li a {
+  @apply dark:text-slate-200 dark:hover:bg-slate-700;
+}
+
 .mdLayout .h3-wrap > .section > ul.icon-list > li a img {
   @apply mr-4 h-6;
 }


### PR DESCRIPTION
Fixed the invisible text in the [AI cheatsheet](https://github.com/Fechin/reference/blob/main/source/_posts/ai.md) which occurs while in Dark mode.

Before:
<img width="1698" height="866" alt="image" src="https://github.com/user-attachments/assets/3cdb153e-96fd-4fdd-926e-9e1c600f2e70" />

Now:
<img width="1675" height="908" alt="image" src="https://github.com/user-attachments/assets/764a4d65-37ef-4832-a5bf-9df7ce43bdcd" />

closes #631 
