### PR TITLE
Fix broken image donate in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Only the `title` and `intro` fields are required, and the other options can be l
 Stay up-to-date with our project by following us on Twitter! Get all the latest news and updates right in your feed.
 It's the perfect way to stay in the loop.
 
-<a href="https://buymeacoffee.com/cheatsheets.zip"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=cheatsheets.zip&button_colour=40DCA5&font_colour=ffffff&font_family=Cookie&outline_colour=000000&coffee_colour=FFDD00" /></a>
+<a href="https://buymeacoffee.com/cheatsheets.zip"><img src="https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&emoji=&slug=cheatsheets.zip&button_colour=40DCA5&font_colour=ffffff&font_family=Cookie&outline_colour=000000&coffee_colour=FFDD00" /></a>
 
 ## 📃 License
 


### PR DESCRIPTION
fix broken image in README by encoding spaces in image url so it renders correctly

before
<img width="880" height="342" alt="image" src="https://github.com/user-attachments/assets/7cfc4e6b-c0f3-4fee-86ca-e0af9fa818af" />

after

<img width="880" height="342" alt="image" src="https://github.com/user-attachments/assets/6b428dcc-c0c6-4267-92ee-aea1de227715" />

