### PR TITLE
Adding mc java/bedorck commands cheatsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,14 @@ Reference provides cheat sheets for the following:
 </details>
 
 <details>
+<summary>Game</summary>
+
+- [Minecraft Java](https://cheatsheets.zip/minecraft-java.html): A comprehensive reference for Minecraft Java Edition (1.20.x) commands.
+- [Minecraft Bedrock](https://cheatsheets.zip/minecraft-bedrock.html): A comprehensive reference for Minecraft Bedrock Edition (1.20.x) commands.
+
+</details>
+
+<details>
 <summary>Other</summary>
 
 - [ASCII Code](https://cheatsheets.zip/ascii-code.html): This cheat sheet is a complete list of ASCII Code Table with

--- a/source/_posts/minecraft-bedrock.md
+++ b/source/_posts/minecraft-bedrock.md
@@ -1,0 +1,264 @@
+---
+title: Minecraft Bedrock Edition
+date: 2023-12-28 12:00:00
+icon: minecraft
+background: bg-[#3C3C3C]
+tags:
+  - minecraft
+  - bedrock
+  - pe
+  - commands
+  - cheats
+  - game
+categories:
+  - Game
+intro: A comprehensive reference for Minecraft Bedrock Edition (1.20.x) commands.
+---
+
+## Target Selectors
+
+| Selector | Description |
+| :--- | :--- |
+| `@p` | Nearest player |
+| `@r` | Random player |
+| `@a` | All players |
+| `@e` | All entities (mobs, items, etc.) |
+| `@s` | The entity executing the command (Self) |
+| `@c` | The player's agent (Education Edition/Code Builder) |
+
+### Selector Arguments
+
+| Argument | Example | Description |
+| :--- | :--- | :--- |
+| `type` | `@e[type=creeper]` | Selects entities of a specific type |
+| `r` / `rm` | `@a[r=10]` | Selects within a max radius (`r`) or min radius (`rm`) |
+| `c` | `@e[c=1]` | Limits the count of targets (nearest first) |
+| `m` | `@a[m=creative]` | Selects players by gamemode |
+| `l` / `lm` | `@a[lm=30]` | Selects by level max (`l`) or min (`lm`) |
+| `name` | `@e[name="Bob"]` | Selects entities with a specific name tag |
+
+## Core Commands
+
+### Teleport (/tp)
+
+Teleport entities to locations or other entities.
+
+```mcfunction
+# Teleport yourself to coordinates
+/tp @s 100 64 -200
+
+# Teleport yourself to another player
+/tp @s "Player Name"
+
+# Teleport relative to current position
+/tp @s ~ ~10 ~
+
+# Teleport with facing direction
+/tp @s ~ ~ ~ facing @p
+```
+
+### Game Mode (/gamemode)
+
+Changes the player's game mode.
+
+```mcfunction
+# Survival Mode (0)
+/gamemode s
+# or
+/gamemode survival
+
+# Creative Mode (1)
+/gamemode c
+# or
+/gamemode creative
+
+# Adventure Mode (2)
+/gamemode a
+# or
+/gamemode adventure
+
+# Spectator Mode (Experimental/New)
+/gamemode spectator
+```
+
+### Give Items (/give)
+
+Gives items to players.
+
+```mcfunction
+# Give a diamond sword
+/give @s diamond_sword
+
+# Give 64 stone
+/give @s stone 64
+
+# Give item with data value (Legacy/Some items)
+# Syntax: /give <target> <item> [amount] [data] [components]
+/give @s wool 1 14 (Red Wool)
+
+# Give item with CanPlaceOn (Adventure mode)
+/give @s stone 1 0 {"minecraft:can_place_on":{"blocks":["grass"]}}
+```
+
+### Experience (/xp)
+
+Adds or levels up experience.
+
+```mcfunction
+# Add 5 levels
+/xp 5L @s
+
+# Add 100 points
+/xp 100 @s
+```
+
+## World Management
+
+### Time (/time)
+
+Sets the world time.
+
+```mcfunction
+# Set to day
+/time set day
+
+# Set to night
+/time set night
+
+# Set specific tick
+/time set 0
+```
+
+### Weather (/weather)
+
+Changes the weather.
+
+```mcfunction
+# Clear weather
+/weather clear
+
+# Rain
+/weather rain
+
+# Thunderstorm
+/weather thunder
+```
+
+### Gamerules (/gamerule)
+
+Sets global world rules.
+
+| Rule | Description |
+| :--- | :--- |
+| `keepinventory` | Keep items on death (true/false) |
+| `dodaylightcycle` | Toggle sun movement (true/false) |
+| `domobspawning` | Toggle mob spawning (true/false) |
+| `mobgriefing` | Toggle mob destruction (true/false) |
+| `doweathercycle` | Toggle weather changes (true/false) |
+| `commandblockoutput` | Toggle command block chat (true/false) |
+| `showcoordinates` | Show coordinates on screen (true/false) |
+
+```mcfunction
+# Enable keep inventory
+/gamerule keepinventory true
+
+# Show coordinates
+/gamerule showcoordinates true
+```
+
+## Entity & Block Manipulation
+
+### Effect (/effect)
+
+Manages status effects.
+
+```mcfunction
+# Give Speed II for 30 seconds
+/effect @s speed 30 2
+
+# Give Night Vision (hide particles)
+/effect @s night_vision 10000 0 true
+
+# Clear all effects
+/effect @s clear
+```
+
+### Fill (/fill)
+
+Fills a volume with blocks.
+
+```mcfunction
+# Fill region with dirt
+/fill ~ ~ ~ ~5 ~5 ~5 dirt
+
+# Replace only air with water
+/fill ~-5 ~-5 ~-5 ~5 ~5 ~5 water 0 replace air
+
+# Fill using block states
+/fill ~ ~ ~ ~10 ~1 ~10 stone ["stone_type"="granite"]
+```
+
+### Setblock (/setblock)
+
+Changes a specific block.
+
+```mcfunction
+# Place a redstone block
+/setblock ~ ~-1 ~ redstone_block
+
+# Destroy block and place air
+/setblock 100 64 100 air 0 destroy
+```
+
+### Enchant (/enchant)
+
+Enchants the held item.
+
+```mcfunction
+# Add Sharpness V
+/enchant @s sharpness 5
+
+# Add Unbreaking III
+/enchant @s unbreaking 3
+```
+
+## Utility Commands
+
+### Locate (/locate)
+
+Finds the nearest biome or structure.
+
+```mcfunction
+# Find nearest village
+/locate structure village
+
+# Find nearest ancient city
+/locate structure ancient_city
+```
+
+### Kill (/kill)
+
+Removes entities.
+
+```mcfunction
+# Kill yourself
+/kill @s
+
+# Kill specific entity type
+/kill @e[type=zombie]
+```
+
+### Ticking Area (/tickingarea)
+
+Keeps chunks loaded even when no players are nearby.
+
+```mcfunction
+# Add a ticking area (radius 4 chunks)
+/tickingarea add circle ~ ~ ~ 4 MyArea
+
+# List all areas
+/tickingarea list
+
+# Remove an area
+/tickingarea remove MyArea
+```

--- a/source/_posts/minecraft-java.md
+++ b/source/_posts/minecraft-java.md
@@ -1,0 +1,265 @@
+---
+title: Minecraft Java Edition
+date: 2023-12-28 12:00:00
+icon: minecraft
+background: bg-[#5B8C5A]
+tags:
+  - minecraft
+  - java
+  - commands
+  - cheats
+  - game
+categories:
+  - Game
+intro: A comprehensive reference for Minecraft Java Edition (1.20.x) commands.
+---
+
+## Target Selectors
+
+| Selector | Description |
+| :--- | :--- |
+| `@p` | Nearest player |
+| `@r` | Random player |
+| `@a` | All players |
+| `@e` | All entities (includes mobs, items, etc.) |
+| `@s` | The entity executing the command (Self) |
+
+### Selector Arguments
+
+| Argument | Example | Description |
+| :--- | :--- | :--- |
+| `type` | `@e[type=skeleton]` | Selects entities of a specific type |
+| `distance` | `@a[distance=..10]` | Selects within a radius (10 blocks) |
+| `limit` | `@e[limit=1]` | Limits the number of targets selected |
+| `sort` | `@a[sort=nearest]` | Sorts selection (nearest, furthest, random, arbitrary) |
+| `gamemode` | `@a[gamemode=creative]` | Selects players in a specific gamemode |
+| `level` | `@a[level=30..]` | Selects players with XP level 30 or higher |
+
+## Core Commands
+
+### Teleport (/tp)
+
+Used to teleport entities to specific locations or other entities.
+
+```mcfunction
+# Teleport yourself to coordinates
+/tp @s 100 64 -200
+
+# Teleport yourself to another player
+/tp @s PlayerName
+
+# Teleport a specific player to you
+/tp PlayerName @s
+
+# Teleport relative to current position (~ is relative)
+/tp @s ~ ~10 ~  (Moves 10 blocks up)
+
+# Teleport with rotation (yaw pitch)
+/tp @s ~ ~ ~ 90 0 (Faces South)
+```
+
+### Game Mode (/gamemode)
+
+Changes the player's game mode.
+
+```mcfunction
+# Survival Mode
+/gamemode survival
+
+# Creative Mode
+/gamemode creative
+
+# Adventure Mode
+/gamemode adventure
+
+# Spectator Mode
+/gamemode spectator
+
+# Apply to other players
+/gamemode creative @a[distance=..20]
+```
+
+### Give Items (/give)
+
+Gives items to players.
+
+```mcfunction
+# Give a diamond sword
+/give @s diamond_sword
+
+# Give 64 stone
+/give @s stone 64
+
+# Give item with NBT data (Unbreakable diamond pickaxe)
+/give @s diamond_pickaxe{Unbreakable:1b}
+```
+
+### Experience (/xp or /experience)
+
+Adds or removes experience points/levels.
+
+```mcfunction
+# Add 5 levels
+/xp add @s 5 levels
+
+# Add 100 points
+/xp add @s 100 points
+
+# Query current level
+/xp query @s levels
+```
+
+## World Management
+
+### Time (/time)
+
+Sets or queries the world time.
+
+```mcfunction
+# Set to day (1000 ticks)
+/time set day
+
+# Set to night (13000 ticks)
+/time set night
+
+# Set to noon (6000 ticks)
+/time set noon
+
+# Set to midnight (18000 ticks)
+/time set midnight
+
+# Add time (skip forward)
+/time add 5000
+```
+
+### Weather (/weather)
+
+Changes the weather.
+
+```mcfunction
+# Clear weather
+/weather clear
+
+# Rain
+/weather rain
+
+# Thunderstorm
+/weather thunder
+
+# Set duration (in seconds)
+/weather clear 600
+```
+
+### Gamerules (/gamerule)
+
+Sets various rules for the world.
+
+| Rule | Description |
+| :--- | :--- |
+| `keepInventory` | If true, players keep items on death |
+| `doDaylightCycle` | If false, time is frozen |
+| `doMobSpawning` | If false, mobs won't spawn naturally |
+| `mobGriefing` | If false, creepers/endermen won't destroy blocks |
+| `doWeatherCycle` | If false, weather never changes |
+| `commandBlockOutput` | If false, command blocks don't spam chat |
+
+```mcfunction
+# Enable keep inventory
+/gamerule keepInventory true
+
+# Disable phantom spawning
+/gamerule doInsomnia false
+```
+
+## Entity & Block Manipulation
+
+### Effect (/effect)
+
+Manages status effects on entities.
+
+```mcfunction
+# Give Speed II for 30 seconds
+/effect give @s speed 30 1
+
+# Give Night Vision infinitely (hide particles)
+/effect give @s night_vision infinite 0 true
+
+# Clear all effects
+/effect clear @s
+```
+
+### Fill (/fill)
+
+Fills a region with a specific block.
+
+```mcfunction
+# Fill a 10x10x10 cube with stone
+/fill ~ ~ ~ ~10 ~10 ~10 stone
+
+# Replace only water with air (drain)
+/fill ~-5 ~-5 ~-5 ~5 ~5 ~5 air replace water
+
+# Create a hollow box of glass
+/fill ~ ~ ~ ~5 ~5 ~5 glass outline
+```
+
+### Setblock (/setblock)
+
+Changes a single block.
+
+```mcfunction
+# Place a torch at current location
+/setblock ~ ~ ~ torch
+
+# Destroy the block (drop item) and place stone
+/setblock ~ ~-1 ~ stone destroy
+```
+
+### Enchant (/enchant)
+
+Enchants the item currently held.
+
+```mcfunction
+# Add Sharpness V
+/enchant @s sharpness 5
+
+# Add Fortune III
+/enchant @s fortune 3
+```
+
+## Utility Commands
+
+### Locate (/locate)
+
+Finds the nearest structure or biome.
+
+```mcfunction
+# Find nearest village
+/locate structure village
+
+# Find nearest cherry grove
+/locate biome cherry_grove
+```
+
+### Kill (/kill)
+
+Removes entities.
+
+```mcfunction
+# Kill yourself
+/kill @s
+
+# Kill all slimes
+/kill @e[type=slime]
+
+# Kill all items on the ground (cleanup)
+/kill @e[type=item]
+```
+
+### Seed (/seed)
+
+Displays the world seed.
+
+```mcfunction
+/seed
+```

--- a/themes/coo/_config.yml
+++ b/themes/coo/_config.yml
@@ -10,6 +10,7 @@ index_categories:
   - Python
   - Database
   - Keyboard Shortcuts
+  - Game
   - Other
 
 # Home recommended posts


### PR DESCRIPTION
This PR adds support for the cheatsheet by including **Minecraft Java & Bedrock 1.20.x commands**.
Everything is complete and ready for review
Please feel free to leave feedback, especially regarding the **icon**

### Icon Note

I initially looked for Minecraft icons online, but most available options have licensing restrictions. For now, I leaved it with the default icon.
If you’re able to create or provide a custom Minecraft icon, feel free to replace it.