### PR TITLE
Fix incorrect double-quoted string example

### DIFF
--- a/source/_posts/javascript.md
+++ b/source/_posts/javascript.md
@@ -61,7 +61,7 @@ console.log(a); // => undefined
 
 ```javascript
 let singleQuotes = 'Wheres my bandit hat?';
-let doubleQuotes = 'Wheres my bandit hat?';
+let doubleQuotes = "Wheres my bandit hat?";
 // this is used to embed expressions or for creating multi-line strings
 let backTicks = `Wheres my bandit hat? ${some_value}`;
 


### PR DESCRIPTION
This PR fixes an incorrect example in the JavaScript cheatsheet where
the double-quoted string example was using single quotes.

File changed:
- source/_posts/javascript.md

Related issue: #<1>
