### PR TITLE
Add igly.ai to AI image editing tools

### DIFF
--- a/source/_posts/ai.md
+++ b/source/_posts/ai.md
@@ -56,6 +56,7 @@ intro:
 - [![Favicon](https://icon.horse/icon/befunky.com) Befunky](https://befunky.com)
 - [![Favicon](https://icon.horse/icon/topazlabs.com/topaz-photo-ai) Topaz photo ai](https://topazlabs.com/topaz-photo-ai)
 - [![Favicon](https://icon.horse/icon/photoroom.com) Photoroom](https://photoroom.com)
+- [![Favicon](https://icon.horse/icon/igly.ai) Igly.ai](https://igly.ai)
 - [![Favicon](https://icon.horse/icon/erase.bg) Erase.bg](https://erase.bg)
 
 {.icon-list .marker-none}


### PR DESCRIPTION
Adds igly.ai to the AI Directory image editing section alongside tools like remove.bg, Topaz Photo AI, Photoroom, and Erase.bg.

igly.ai is an AI image editing platform for background removal, inpainting, upscaling, and generative fill.

Demo: https://www.youtube.com/watch?v=HB2E1WZ12is