### PR TITLE
Fix GitHub capitalization in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Reference provides cheat sheets for the following:
 - [Twitter](https://cheatsheets.zip/twitter.html): A visual cheat-sheet for the 26 keyboard shortcuts found on Twitter
 - [Android Studio](https://cheatsheets.zip/android-studio.html): A visual cheat-sheet for the 130 keyboard shortcuts
   found in the Android Studio software
-- [Github](https://cheatsheets.zip/github.html): A visual cheat-sheet for the 80 keyboard shortcuts found on Github.com
+- [GitHub](https://cheatsheets.zip/github.html): A visual cheat-sheet for the 80 keyboard shortcuts found on GitHub.com
 - [Shopify](https://cheatsheets.zip/shopify.html): A visual cheat-sheet for the 50 keyboard shortcuts found on the
   Shopify website
 - [Zoom](https://cheatsheets.zip/zoom.html): A visual cheat-sheet for the 32 keyboard shortcuts found in Zoom. These
@@ -376,7 +376,7 @@ this project a truly resource. Please note that the primary domain for accessing
 For consistency, we encourage you to refer to the [https://cheatsheets.zip/quickref](https://cheatsheets.zip/quickref)
 when creating or editing cheat sheets. To get started with development, follow these steps:
 
-1. Clone Github repo `git clone https://github.com/Fechin/reference.git`
+1. Clone GitHub repo `git clone https://github.com/Fechin/reference.git`
 2. Install `npm` package manager (Read
    [installation guide](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm))
 3. Run `npm install` in the root folder to install dependencies.

--- a/source/_posts/github.md
+++ b/source/_posts/github.md
@@ -1,5 +1,5 @@
 ---
-title: Github
+title: GitHub
 date: 2022-11-23 16:23:31.704787
 background: bg-[#17191e]
 label:
@@ -9,7 +9,7 @@ tags:
 categories:
   - Keyboard Shortcuts
 intro: |
-  A visual cheat-sheet for the 80 keyboard shortcuts found on Github.com
+  A visual cheat-sheet for the 80 keyboard shortcuts found on GitHub.com
 ---
 
 ## Keyboard Shortcuts
@@ -173,4 +173,4 @@ intro: |
 
 ## Also see
 
-- [Keyboard shortcuts for Github](https://help.github.com/articles/using-keyboard-shortcuts/) _(help.github.com)_
+- [Keyboard shortcuts for GitHub](https://help.github.com/articles/using-keyboard-shortcuts/) _(help.github.com)_

--- a/source/_posts/homebrew.md
+++ b/source/_posts/homebrew.md
@@ -113,7 +113,7 @@ List all the current tapped repositories (taps)
 brew tap
 ```
 
-Tap a formula repository from Github using https for tap https://github.com/user/homebrew-repo
+Tap a formula repository from GitHub using https for tap https://github.com/user/homebrew-repo
 
 ```bash
 brew tap <user/repo>
@@ -133,7 +133,7 @@ brew untap <user/repo>
 
 ### Cask
 
-Tap the Cask repository from Github.
+Tap the Cask repository from GitHub.
 
 ```bash
 brew tap homebrew/cask

--- a/source/_posts/quickref.md
+++ b/source/_posts/quickref.md
@@ -16,7 +16,7 @@ plugins:
 
 ### Develop Setup
 
-- Clone Repository [View on Github](https://github.com/Fechin/reference.git)
+- Clone Repository [View on GitHub](https://github.com/Fechin/reference.git)
   ```shell script {.wrap}
   $ git clone https://github.com/Fechin/reference.git
   ```


### PR DESCRIPTION
Summary:
- Updates `Github` to `GitHub` in documentation text.
- Leaves descriptions, links, and ordering unchanged.

Testing:
- git diff --check
- rg "Github" on touched files

AI assistance: This documentation fix was prepared with AI assistance and reviewed before submission.
