### PR TITLE
docs: add WheelPage quick reference

### DIFF
--- a/source/_posts/wheelpage.md
+++ b/source/_posts/wheelpage.md
@@ -1,0 +1,114 @@
+---
+title: WheelPage
+date: 2026-07-16 00:04:31
+background: bg-gradient-to-br from-orange-400 via-pink-500 to-purple-500
+tags:
+  - Tool
+  - Productivity
+  - Education
+categories:
+  - Other
+intro: Quick-reference cheatsheet for WheelPage — a free online random wheel, picker, and decision-making tool.
+plugins:
+  - copyCode
+---
+
+## Essentials
+
+### What is WheelPage?
+
+**[WheelPage](https://wheelpage.com/)** is a free online random wheel generator for quick decisions, raffles, games, classroom activities, and everyday choices. Add names, prizes, tasks, or ideas, then spin the wheel to pick a random result.
+
+- **Core use cases**: Classroom name picking, team selection, giveaways, party games, and everyday decisions.
+- **Login**: Not required.
+- **Download**: Not required; it runs directly in the browser.
+- **Cost**: Free to use.
+
+### Key Features {.col-span-2}
+
+| Feature                       | Description                                                         |
+| :---------------------------- | :------------------------------------------------------------------ |
+| **Custom entries**            | Add names, options, prizes, tasks, or ideas to the wheel.           |
+| **Entries and results views** | Switch between editing wheel entries and reviewing results.         |
+| **Preset management**         | Reuse sets of options for recurring activities and decisions.       |
+| **Cross-device access**       | Use the wheel from desktop, tablet, or mobile browsers.             |
+| **Fast workflow**             | Open the page, enter choices, and spin without creating an account. |
+| **Multiple languages**        | Available in English, Simplified Chinese, Spanish, and Russian.     |
+
+## How to Use
+
+### Basic Workflow
+
+1. Open the [WheelPage random wheel](https://wheelpage.com/).
+2. Replace the default options with names, prizes, tasks, or choices.
+3. Add or remove entries until the wheel matches your activity.
+4. Spin the wheel and wait for the random result.
+5. Switch to the results view when you need to review recent outcomes.
+
+### Choosing Good Entries
+
+- Keep labels short enough to remain readable on the wheel.
+- Use one entry per line when preparing a classroom or raffle list.
+- Check spelling before spinning in front of a group.
+- Use consistent labels when choosing between teams, tasks, or prizes.
+- Prepare reusable presets for recurring classes, meetings, or games.
+
+## Common Uses
+
+### Classroom Activities
+
+- Pick a student to answer the next question.
+- Assign students to groups or classroom roles.
+- Choose a warm-up, writing prompt, or review topic.
+- Select the next activity without teacher bias.
+
+### Raffles and Giveaways
+
+- Add participant names as wheel entries.
+- Add prizes when the winner is already known.
+- Use the wheel as a visible draw during a live event or stream.
+- Review the final list before spinning to avoid missing entries.
+
+### Games and Events
+
+- Choose teams, players, challenges, or party activities.
+- Pick the next speaker or performer.
+- Decide turn order for a group game.
+- Turn a list of ideas into an interactive audience activity.
+
+### Everyday Decisions
+
+- Choose what to eat, watch, play, or do next.
+- Break ties between several acceptable options.
+- Create a simple yes-or-no wheel.
+- Randomly assign chores, tasks, or meeting topics.
+
+## Companion Tools
+
+### Quick Randomizers {.col-span-2}
+
+| Tool                                                                  | Best for                                                           |
+| :-------------------------------------------------------------------- | :----------------------------------------------------------------- |
+| **[Flip a Coin](https://wheelpage.com/coin-flip/)**                   | Fast heads-or-tails decisions.                                     |
+| **[Dice Roller](https://wheelpage.com/dice-roller/)**                 | Rolling dice in a browser-based 3D scene.                          |
+| **[Rock Paper Scissors](https://wheelpage.com/rock-paper-scissors/)** | Choosing rock, paper, or scissors and seeing the result instantly. |
+
+## Quick Reference
+
+### Before You Spin
+
+- Confirm every eligible name or option is included.
+- Remove duplicates unless repeated entries are intentional.
+- Make sure the wheel is visible to participants when transparency matters.
+- Explain whether a selected entry remains eligible for later rounds.
+
+### Which Tool Should I Use?
+
+| Need                             | Recommended tool       |
+| :------------------------------- | :--------------------- |
+| Pick one item from a custom list | WheelPage random wheel |
+| Make a binary decision           | Flip a Coin            |
+| Generate a dice result           | Dice Roller            |
+| Play a quick hand game           | Rock Paper Scissors    |
+
+{.show-header}


### PR DESCRIPTION
Add a practical WheelPage cheat sheet covering core usage, classroom activities, raffles, games, everyday decisions, and companion randomizer tools.