### PR TITLE
docs: add git switch commands to Git cheatsheet

### DIFF
--- a/source/_posts/git.md
+++ b/source/_posts/git.md
@@ -153,13 +153,13 @@ $ git branch -av
 Switch to my_branch, and update working directory
 
 ```shell script
-$ git checkout my_branch
+$ git switch my_branch
 ```
 
 Create a new branch called new_branch
 
 ```shell script
-$ git checkout -b new_branch
+$ git switch -c new_branch
 ```
 
 Delete the branch called my_branch


### PR DESCRIPTION
## What I changed

While going through the Git cheatsheet, I noticed that the branch section uses `git checkout` for switching to an existing branch and creating a new branch.

I updated these two examples to use the dedicated `git switch` commands:

- `git switch my_branch` — switch to an existing branch
- `git switch -c new_branch` — create and switch to a new branch

The reason for this change is that `git switch` is specifically designed for branch switching and creation, making the commands clearer and easier to understand for people learning Git. `git checkout` is still a valid Git command, but it is used for several different purposes, whereas `git switch` makes the branch-related operation more explicit.

I kept the change limited to these two examples in the Git cheatsheet.